### PR TITLE
Fix to multiple Github workflow invocations on release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: main
 
-on: [pull_request, release]
+on:
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   tests:


### PR DESCRIPTION
* Fixed multiple Github workflow invocations on release, resulting in PyPi publish errors (duplicate package). Github workflow is now limited to `release:published` event instead of  triggering on all `release:*` ones to prevent multiple invocation on single release