### PR TITLE
Documentation update

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+sonar.sources=src
+sonar.tests=tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include pyproject.toml
 
 # Include the README
-include *.md
+include *.rst
 
 # Include the license file
 include LICENSE

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ of peripherals:
 
 ... and probably others
 
+The package implements asynchronous I/O over most of code paths using
+[`asyncio`](https://docs.python.org/3/library/asyncio.html).
+
 # Disclaimer
 
 The author has no affiliation or any relationship to any of the hardware
@@ -53,11 +56,62 @@ devices using EV1527, PT2262 protocols. The mobile application also mentions
 some devices using 2.4GHz, although details of the protocols haven't been
 identified as no such hardware has been available for experimentation.
 
+# Known caveats
+
+* Wireless shutter sensor (WRDS01) doesn't send anything on sensor closed, only
+  when opened. In contrast, WDS07 wireless door sensor does both.
+* Wireless relays (at least JDQ) use same RF code for switching on and off,
+  when configured in toggle mode. That means a RF signal repeater will make
+  controlling such relays unpredictable, since the code will be sent more than
+  once.
+* Low battery notifications for wireless sensors (at least for WDS07 and WSD02)
+  are often missing, either due to the sensors not sending them or the device
+  doesn't receive those.
+* Wired sensors toggle on line state change, i.e. those aren't limited to have
+  normal closed (NC) or normal open (NO) contacts only. Best used with NC
+  contact sensors though, since an intruder cutting the line will trigger the
+  alarm.
+
+# Enabling device notifications
+
+There is a hidden device capability to send protocol notifications over the
+WiFi interface. The notifications are done using broadcast UDP packets with
+source/destination ports being `45000:12901` (non-configurable), and sent when
+the device has IP address of its WiFi interface set to `10.10.10.250`. That is
+the same IP the device will allocate to the WiFi interface when AP (access
+point is enabled). Please note enabling the AP *is not* required for the
+notifications to be sent, only the IP address matters. Likely the firmware does
+a check internally and enables those when corresponding IP address is found on
+the WiFi interface.
+
+Please see
+[Protocol](https://pyg90alarm.readthedocs.io/en/stable/protocol.html)
+documentation for further details on the device notifications.
+
+Depending on your network setup, ensuring the `10.10.10.250` IP address is
+allocated to the WiFi interface of the device might be as simple as DHCP
+reservation. Please check the documentation of your networking gear on how to
+set the IP address allocation up.
+
+*NOTE* Since the IP address trick above isn't something the device exposes to the
+user, the functionality might change or even cease functioning upon a firmware
+upgrade!
+
+*NOTE 2* The device notifications in question are fully local with no dependency
+on the cloud or Internet connection on the device.
+
+*NOTE 3* If IP address trick doesn't work for you by a reason, the package will
+still be able to perform the key functions - for example, arming or disarming
+the panel, or reading the list of sensors. However, the sensor status will not
+be reflected and those will always be reported as inactive, since there is no
+way to read their state in a polled manner.
+
 # Quick start
 
-TBD
+    $ pip install pyg90alarm
 
 # Documentation
 
-Please see [online documentation](https://pyg90alarm.readthedocs.io) for details on the protocol, its
-security, supported commands and the API package provides.
+Please see [online documentation](https://pyg90alarm.readthedocs.io) for
+details on the protocol, its security, supported commands and the API package
+provides.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,15 @@
 .. image::  https://github.com/hostcc/pyg90alarm/actions/workflows/main.yml/badge.svg?branch=master
    :target: https://github.com/hostcc/pyg90alarm/tree/master
+   :alt: Github workflow status
 .. image:: https://readthedocs.org/projects/pyg90alarm/badge/?version=stable
    :target: https://pyg90alarm.readthedocs.io/en/stable
+   :alt: ReadTheDocs status
+.. image:: https://img.shields.io/github/v/release/hostcc/pyg90alarm
+   :target: https://github.com/hostcc/pyg90alarm/releases/latest
+   :alt: Latest GitHub release
+.. image:: https://img.shields.io/pypi/v/pyg90alarm
+   :target: https://pypi.org/project/pyg90alarm/
+   :alt: Latest PyPI version
 
 Description
 ===========

--- a/README.rst
+++ b/README.rst
@@ -51,13 +51,13 @@ And the list of sensors, actual set of device should be notable larger as many
 of other manufacturers produce similar items. The names in parenthesis are
 taken from the alarm system documentation, for example, `Home Alarm GB90-Plus <https://archive.org/details/HomeAlarmGB90-Plus/G90B%20plus%20WIFIGSMGPRS%20alarm%20system%20user%20manual/page/n7/mode/2up>`_.
 
-  * Wired PIR sensors
-  * Wireless PIR sensors (WPD01, WMS08)
-  * Door/window sensors (WDS07, WRDS01)
-  * Water leak sensors (LSTC01)
-  * Smoke sensors (WSD02)
-  * Gas sensors (WGD01)
-  * Switches/relays (JDQ)
+* Wired PIR sensors
+* Wireless PIR sensors (WPD01, WMS08)
+* Door/window sensors (WDS07, WRDS01)
+* Water leak sensors (LSTC01)
+* Smoke sensors (WSD02)
+* Gas sensors (WGD01)
+* Switches/relays (JDQ)
 
 Basically, the alarm system uses 433 MHz communications for the wireless
 devices using EV1527, PT2262 protocols. The mobile application also mentions

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
-[![master](https://github.com/hostcc/pyg90alarm/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/hostcc/pyg90alarm/tree/master)
-[![Documentation Status](https://readthedocs.org/projects/pyg90alarm/badge/?version=stable)](https://pyg90alarm.readthedocs.io/en/stable/?badge=stable)
+.. image::  https://github.com/hostcc/pyg90alarm/actions/workflows/main.yml/badge.svg?branch=master
+   :target: https://github.com/hostcc/pyg90alarm/tree/master
+.. image:: https://readthedocs.org/projects/pyg90alarm/badge/?version=stable
+   :target: https://pyg90alarm.readthedocs.io/en/stable
 
-# Description
+Description
+===========
 
 Python package to control G90-based alarm systems.
 
@@ -9,21 +12,24 @@ Many manufacturers sell such systems under different brands - Golden Security,
 PST, Kerui and others. Those are cheap low-end systems, typically equipped with
 WiFi and possible GSM interfaces for connectivity, and support different range
 of peripherals:
+
 * Wired and wireless sensors
 * Relays (switches)
 
 ... and probably others
 
 The package implements asynchronous I/O over most of code paths using
-[`asyncio`](https://docs.python.org/3/library/asyncio.html).
+`asyncio <https://docs.python.org/3/library/asyncio.html>`_.
 
-# Disclaimer
+Disclaimer
+==========
 
 The author has no affiliation or any relationship to any of the hardware
 vendors in question. The code has been created upon many trial and error
 iterations.
 
-# Motivation
+Motivation
+==========
 
 The primary motivation creating the code is the comfort of using the security
 system - the mobile applications provided by the vendor, called "Carener", is
@@ -32,16 +38,18 @@ integrated into larger ecosystems, like Home Assistant, HomeKit and such.
 Hence, the code has been created to interact with the security system using
 Python, and it opens up a way for further integrations.
 
-# Supported hardware
+Supported hardware
+==================
 
 It mightn't possible to list every system supported by the package due to
 manufacturers name the products differently.  Here is the list of hardware
 known to work with the package:
-* [PST G90B Plus](http://www.cameralarms.com/products/auto_dial_alarm_system/185.html)
+
+* `PST G90B Plus <http://www.cameralarms.com/products/auto_dial_alarm_system/185.html>`_
 
 And the list of sensors, actual set of device should be notable larger as many
 of other manufacturers produce similar items. The names in parenthesis are
-taken from the alarm system documentation, for example, [Home Alarm GB90-Plus](https://archive.org/details/HomeAlarmGB90-Plus/G90B%20plus%20WIFIGSMGPRS%20alarm%20system%20user%20manual/page/n7/mode/2up).
+taken from the alarm system documentation, for example, `Home Alarm GB90-Plus <https://archive.org/details/HomeAlarmGB90-Plus/G90B%20plus%20WIFIGSMGPRS%20alarm%20system%20user%20manual/page/n7/mode/2up>`_.
 
   * Wired PIR sensors
   * Wireless PIR sensors (WPD01, WMS08)
@@ -56,7 +64,8 @@ devices using EV1527, PT2262 protocols. The mobile application also mentions
 some devices using 2.4GHz, although details of the protocols haven't been
 identified as no such hardware has been available for experimentation.
 
-# Known caveats
+Known caveats
+=============
 
 * Wireless shutter sensor (WRDS01) doesn't send anything on sensor closed, only
   when opened. In contrast, WDS07 wireless door sensor does both.
@@ -72,12 +81,13 @@ identified as no such hardware has been available for experimentation.
   contact sensors though, since an intruder cutting the line will trigger the
   alarm.
 
-# Enabling device notifications
+Enabling device notifications
+=============================
 
 There is a hidden device capability to send protocol notifications over the
 WiFi interface. The notifications are done using broadcast UDP packets with
-source/destination ports being `45000:12901` (non-configurable), and sent when
-the device has IP address of its WiFi interface set to `10.10.10.250`. That is
+source/destination ports being ``45000:12901`` (non-configurable), and sent when
+the device has IP address of its WiFi interface set to ``10.10.10.250``. That is
 the same IP the device will allocate to the WiFi interface when AP (access
 point is enabled). Please note enabling the AP *is not* required for the
 notifications to be sent, only the IP address matters. Likely the firmware does
@@ -85,33 +95,37 @@ a check internally and enables those when corresponding IP address is found on
 the WiFi interface.
 
 Please see
-[Protocol](https://pyg90alarm.readthedocs.io/en/stable/protocol.html)
-documentation for further details on the device notifications.
+`protocol documentation <https://pyg90alarm.readthedocs.io/en/stable/protocol.html>`_
+for further details on the device notifications.
 
 Depending on your network setup, ensuring the `10.10.10.250` IP address is
 allocated to the WiFi interface of the device might be as simple as DHCP
 reservation. Please check the documentation of your networking gear on how to
 set the IP address allocation up.
 
-*NOTE* Since the IP address trick above isn't something the device exposes to the
-user, the functionality might change or even cease functioning upon a firmware
-upgrade!
+.. note:: Since the IP address trick above isn't something the device exposes
+   to the user, the functionality might change or even cease functioning upon a
+   firmware upgrade!
 
-*NOTE 2* The device notifications in question are fully local with no dependency
-on the cloud or Internet connection on the device.
+.. note:: The device notifications in question are fully local with no
+   dependency on the cloud or Internet connection on the device.
 
-*NOTE 3* If IP address trick doesn't work for you by a reason, the package will
-still be able to perform the key functions - for example, arming or disarming
-the panel, or reading the list of sensors. However, the sensor status will not
-be reflected and those will always be reported as inactive, since there is no
-way to read their state in a polled manner.
+.. note:: If IP address trick doesn't work for you by a reason, the package
+   will still be able to perform the key functions - for example, arming or
+   disarming the panel, or reading the list of sensors. However, the sensor
+   status will not be reflected and those will always be reported as inactive,
+   since there is no way to read their state in a polled manner.
 
-# Quick start
+Quick start
+===========
 
-    $ pip install pyg90alarm
+.. code:: shell
 
-# Documentation
+   pip install pyg90alarm
 
-Please see [online documentation](https://pyg90alarm.readthedocs.io) for
+Documentation
+=============
+
+Please see `online documentation <https://pyg90alarm.readthedocs.io>`_ for
 details on the protocol, its security, supported commands and the API package
 provides.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,8 @@ author = 'Ilia Sotnikov'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'myst_parser',
+    'sphinx.ext.intersphinx',
+    'enum_tools.autoenum',
 ]
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
@@ -33,7 +34,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 autodoc_default_options = {
     'members': True,
@@ -46,6 +47,10 @@ autodoc_default_options = {
 source_suffix = {
     '.rst': 'restructuredtext',
     '.md': 'markdown',
+}
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
     'enum_tools.autoenum',
+    'sphinx.ext.autosectionlabel',
 ]
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,13 +2,13 @@
    :maxdepth: 2
    :hidden:
 
+   Introduction <self>
    protocol
    api-docs
 
 .. contents::
 
-.. include:: ../README.md
-   :parser: myst_parser.sphinx_
+.. include:: ../README.rst
 
 
 Indices and tables

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -59,7 +59,9 @@ command code being sent.
 
 If the command expects parameters, they are provided as nested array, where
 ``code`` is the first element and duplicates ``code`` from the parent.
-Remaining elements in the nested list represent the parameters.
+Remaining elements in the nested JSON array represent the parameters:
+
+:samp:`ISTART[{code},{subcode}[{code},[parameters,...]]]IEND\\0`
 
 If the command doesn't expect any parameters the request should contain empty
 JSON string ``""`` for the nested array:
@@ -70,24 +72,91 @@ Some examples:
 
 - Get host config:
 
-  ``ISTART[106,106,""]IEND\0``
+  :samp:`ISTART[106,106,""]IEND\0`
+
 - Turn on device (relay) with ID 12 and subindex 2 (3rd port of multichannel
   device):
 
-  ``ISTART[137,137,[137,[12,0,2]]]IEND\0``
+  :samp:`ISTART[137,137,[137,[12,0,2]]]IEND\0`
 
 
 Response
 --------
 
-  ``ISTART[payload]IEND\0``
+Command responses has structure similar to the requests with regards to
+start/end markers, terminator and string encoding. Generic format is:
 
-  ``ISTARTIEND\0``
+:samp:`ISTART[{payload}]IEND\\0`
 
-  ``ISTART[code,[response]]IEND\0``
+If response doesn't contain ant data it will have only start/end markers and terminator:
+
+:samp:`ISTARTIEND\\0`
+
+In a generic form the ``payload`` is JSON encoded array contains following elements:
+
+:samp:`[{code},[response]]`
+
+The ``code`` duplicates one send in the request and could be used to verify the
+response if for the command sent previously.
+The ``response`` is the JSON array containing command-specific response.
+
+Some examples:
+
+- Host status response (command ``100``):
+
+  :samp:`ISTART[100,[3,"{panel phone number}","TSV018-C3SIA","205","206"]]IEND`
+
+  Where ``TSV018-C3SIA`` is product name, ``205`` is HW version of MCU (main
+  unit) and ``206`` is HW version of Wifi module.
 
 Pagination
 ----------
 
+Certain commands operate over list of records and require pagination.
+Such commands require pagination data to be sent in the request, indicating
+range of records requested - :samp:`[{start record},{end record}]`:
+
+:samp:`ISTART[{code},{subcode},[{code},[{start record},{end record}]]]IEND\\0`
+
+Both ``start record`` and ``end record`` are one-based and indicate the
+inclusive range of records.
+
+Response to paginated commands comes as JSON array with pagination header as the first element:
+
+:samp:`ISTART[{code},[[{total records},{start record},{count}],[{response element,...}]]]IEND\\0`
+
+Same as for regular commands, the ``code`` duplicates one sent in the request.
+The pagination header being first element in the payload array has following
+fields:
+
+- ``total records`` total number of records available (one-based)
+- ``start record`` the index of the starting record (one-based)
+- ``count`` number of records returned
+
+The protocol seems correctly handle the scenario requesting the number of
+records larger then those available (difference between ``end record`` and
+``start record``), although only if ``start record`` is within available
+records - if ``start record`` specifies one outside of the range available the
+device will return empty response.
+
+
 Notification protocol
 ---------------------
+
+The alarm panel sends notifications and alerts on various events. The
+notifications are send unconditionally, that is you cannot disable them, while
+alerts are only sent if enabled in the device.
+
+To receive the notifications from the device you need to follow the steps
+outlined in :ref:`Enabling device notifications`.
+
+The device uses UDP protocol and ``12901`` target port, each notification is
+sent in separate packets having the following structure:
+
+:samp:`[{message ID},[{message code},[data]]]\\0`
+
+All messages are terminated with binary zero (shown below as ``\0``), and text
+uses ``utf-8`` encoding.
+
+Data varies across different notification and alert types, see
+`pyg90alarm/device_notifications.py <../../src/pyg90alarm/device_notifications.py>`_. 

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -1,4 +1,93 @@
-Protocol
+G90 alarm panel protocol
+========================
+
+.. contents::
+
+There are two protocols a G90 alarm system uses: one towards its own cloud and
+another for the clients on local network over WiFi connection.
+
+By the time of writing the following protocol versions are in use:
+
+* Cloud: version 1.1
+* Local: version 1.2
+
+.. note:: The rest of the document describes only the local protocol, version 1.2
+
+The local protocol is UDP based, using destination port (alarm panel side) of
+``12368``. It has been noticed the vendor provided applications (at least, on iOS)
+uses source port ``45000`` when sending protocol commands to the panel,
+although further experimentation revealed ephemeral ports could be used
+instead.
+
+The protocol commands are text based using JSON encoded payload and ``utf-8``
+encoding. See below for requests and responses wire format.
+
+Security
 --------
 
-TBD
+.. warning:: The local protocol *does not* provide any security, neither
+   authentication, authorization or encryption.
+
+That translates to:
+
+* Any client on the local network can successfully send the protocol commands
+  to the panel, including arming, disarming, configuring etc.
+* The protocol expects both requests and responses in clear text
+
+You should consider implementing network controls to, at least, limit on what
+clients could interact with the alarm control panel. The implementation might
+consider firewall rules, VLANs and other measures available in the network
+equipment you user
+
+Request
+-------
+
+The protocol request uses the following format, where ``ISTART`` and ``IEND``
+are always sent as start/end markers, and the request should be terminated with
+binary zero (shown below as ``\0``):
+
+:samp:`ISTART{payload}IEND\\0`
+
+In a generic form the ``payload`` is JSON encoded array contains following elements:
+
+:samp:`[{code},{subcode},[code,[parameters,...]]]``
+
+Typically, both ``code`` and ``subcode`` contain equal values and specify the
+command code being sent.
+
+.. note:: Both elements are encoded as integers not strings!
+
+If the command expects parameters, they are provided as nested array, where
+``code`` is the first element and duplicates ``code`` from the parent.
+Remaining elements in the nested list represent the parameters.
+
+If the command doesn't expect any parameters the request should contain empty
+JSON string ``""`` for the nested array:
+
+:samp:`ISTART[{code},{subcode},""]IEND\\0`
+
+Some examples:
+
+- Get host config:
+
+  ``ISTART[106,106,""]IEND\0``
+- Turn on device (relay) with ID 12 and subindex 2 (3rd port of multichannel
+  device):
+
+  ``ISTART[137,137,[137,[12,0,2]]]IEND\0``
+
+
+Response
+--------
+
+  ``ISTART[payload]IEND\0``
+
+  ``ISTARTIEND\0``
+
+  ``ISTART[code,[response]]IEND\0``
+
+Pagination
+----------
+
+Notification protocol
+---------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-myst-parser
+sphinx-rtd-theme
+enum-tools[sphinx]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 import pathlib
 
 here = pathlib.Path(__file__).parent.resolve()
-long_description = (here / 'README.md').read_text(encoding='utf-8')
+long_description = (here / 'README.rst').read_text(encoding='utf-8')
 
 setup(
     name='pyg90alarm',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     },
     description='G90 Alarm system protocol',
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type='text/x-rst',
     url='https://github.com/hostcc/pyg90alarm',
     author='Ilia Sotnikov',
     author_email='hostcc@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(
             'asynctest',
         ],
         'docs': [
-            'Sphinx',
-            'myst-parser',
+            'sphinx',
+            'sphinx-rtd-theme',
         ],
     },
 

--- a/src/pyg90alarm/__init__.py
+++ b/src/pyg90alarm/__init__.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Python package to control G90-based alarm systems.
 """
 
 from .alarm import G90Alarm  # noqa: F401

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -126,15 +126,15 @@ class G90Alarm:
 
     def paginated_result(self, code, start=1, end=None):
         """
-        Invokes a paginated command, that is - command operating on a range of
-        records.
+        Returns asynchronous generator to for a paginated command, that is -
+        command operating on a range of records.
 
         :param code: Command code
         :type code: :class:`.G90Commands`
         :param int start: Starting record position (one-based)
         :param int end: Ending record position (one-based)
-        :return: :class:`.G90PaginatedResult` that contains the result of
-         command invocation
+        :return: :class:`.G90PaginatedResult` being asynchronous generator
+          over the result of command invocation
         """
         return G90PaginatedResult(
             self._host, self._port, code, start, end, sock=self._sock
@@ -143,7 +143,11 @@ class G90Alarm:
     @classmethod
     async def discover(cls):
         """
-        tbd
+        Initiates discovering devices available in the same network segment, by
+        using global broadcast address as the destination.
+
+        :return: List of discovered devices
+        :rtype: list[{'guid', 'host', 'port'}]
         """
         return await G90Discovery(
             port=REMOTE_PORT,
@@ -153,7 +157,14 @@ class G90Alarm:
     @classmethod
     async def targeted_discover(cls, device_id):
         """
-        tbd
+        Initiates discovering devices available in the same network segment
+        using targeted protocol, that is - specifying target device GUID in the
+        request, so only the specific device should respond to the query.
+
+        :param device_id: GUID of the target device to discover
+        :type device_id: str
+        :return: List of discovered devices
+        :rtype: list[{'guid', 'host', 'port'}]
         """
         return await G90TargetedDiscovery(
             device_id=device_id,
@@ -165,7 +176,12 @@ class G90Alarm:
     @property
     async def sensors(self):
         """
-        tbd
+        Provides list of sensors configured in the device. Please note the list
+        is cached upon first call, so you need to re-instantiate the class to
+        reflect any updates there.
+
+        :return: List of sensors
+        :rtype: list(:class:`.G90Sensor`)
         """
         if not self._sensors:
             sensors = self.paginated_result(
@@ -182,7 +198,14 @@ class G90Alarm:
     @property
     async def devices(self):
         """
-        tbd
+        Provides list of devices (switches) configured in the device. Please
+        note the list is cached upon first call, so you need to re-instantiate
+        the class to reflect any updates there. Multi-node devices, those
+        having multiple ports, are expanded into corresponding number of
+        resulting entries.
+
+        :return: List of devices
+        :rtype: list(:class:`.G90Device`)
         """
         if not self._devices:
             cmd = self.paginated_result(
@@ -204,7 +227,11 @@ class G90Alarm:
     @property
     async def host_info(self):
         """
-        tbd
+        Provides the device information (for example hardware versions, signal
+        levels etc.).
+
+        :return: Device information
+        :rtype: Instance of :class:`.G90HostInfo`
         """
         res = await self.command(G90Commands.GETHOSTINFO)
         return G90HostInfo(*res)
@@ -212,7 +239,12 @@ class G90Alarm:
     @property
     async def host_status(self):
         """
-        tbd
+        Provides the device status (for example, armed or disarmed, configured
+        phone number, product name etc.).
+
+        :return: Device information
+        :rtype: Instance of :class:`.G90HostStatus`
+
         """
         res = await self.command(G90Commands.GETHOSTSTATUS)
         return G90HostStatus(*res)
@@ -231,14 +263,29 @@ class G90Alarm:
     @property
     async def user_data_crc(self):
         """
-        tbd
+        Retieves checksums (CRC) for different on-device databases (history,
+        sensors etc.). Might be used to detect if there is a change in a
+        particular database.
+
+        .. note:: Note that due to a bug in the firmware CRC for sensos and
+          device databases change on each call even if there were no changes
+
+        :return: Instance of :class:`.G90UserDataCRC` containing checksums for
+          different databases
         """
         res = await self.command(G90Commands.GETUSERDATACRC)
         return G90UserDataCRC(*res)
 
     async def history(self, start=1, count=1):
         """
-        tbd
+        Retrieves event history from the device.
+
+        :param start: Starting record number (one-based)
+        :type start: int
+        :param count: Number of records to retrieve
+        :type count: int
+        :return: List of history entries
+        :rtype: list[:class:`.G90History`]
         """
         res = self.paginated_result(G90Commands.GETHISTORY,
                                     start, count)
@@ -248,7 +295,8 @@ class G90Alarm:
     async def _internal_sensor_cb(self, idx, name, occupancy=True):
         """
         Callback that invoked both for sensor notifications and door open/close
-        alerts, since the logic for both is same and could be reused.
+        alerts, since the logic for both is same and could be reused. Please
+        note the callback is for internal use by the class.
 
         :param int idx: The index of the sensor the callback is invoked for.
          Please note the index is a property of sensor, not the direct index of
@@ -320,21 +368,23 @@ class G90Alarm:
     @property
     def sensor_callback(self):
         """
-        tbd
+        Get or set sensor activity callback, the callback is invoked when sensor
+        activates.
+
+        :type: .. py:function:: ()(idx, name, occupancy)
         """
         return self._sensor_cb
 
     @sensor_callback.setter
     def sensor_callback(self, value):
-        """
-        tbd
-        """
         self._sensor_cb = value
 
     async def _internal_door_open_close_cb(self, idx, name, is_open):
         """
         Callback that invoked when door open/close alert comes from the alarm
-        panel.
+        panel. Please note the callback is for internal use by the class.
+
+        .. seealso:: `method`:_internal_sensor_cb for arguments
         """
         # Same internal callback is reused both for door open/close alerts and
         # sensor notifications. The former adds reporting when a door is
@@ -346,7 +396,11 @@ class G90Alarm:
     @property
     def door_open_close_callback(self):
         """
-        tbd
+        Get or set door open/close callback, the callback is invoked when door
+        is opened or closed (if corresponding alert is configured on the
+        device).
+
+        :type: ()(idx: int, name: str, is_open: bool)
         """
         return self._door_open_close_cb
 
@@ -359,27 +413,34 @@ class G90Alarm:
 
     async def _internal_armdisarm_cb(self, state):
         """
-        tbd
+        Callback that invoked when the device is armed or disarmed. Please note
+        the callback is for internal use by the class.
+
+        :param state: Device state (armed, disarmed, armed home)
+        :type state: :class:`G90ArmDisarmTypes`
         """
         G90Callback.invoke(self._armdisarm_cb, state)
 
     @property
     def armdisarm_callback(self):
         """
-        tbd
+        Get or set device arm/disarm callback, the callback is invoked when
+        device state changes.
+
+        :type: ()(state: :class:`.G90ArmDisarmTypes`)
         """
         return self._armdisarm_cb
 
     @armdisarm_callback.setter
     def armdisarm_callback(self, value):
-        """
-        tbd
-        """
         self._armdisarm_cb = value
 
     async def listen_device_notifications(self, sock=None):
         """
-        tbd
+        Starts internal listener for device notifications/alerts.
+
+        :param sock: socket instance to listen on, mostly used by tests
+        :type: socket.socket
         """
         self._notifications = G90DeviceNotifications(
             sensor_cb=self._internal_sensor_cb,
@@ -390,28 +451,28 @@ class G90Alarm:
 
     def close_device_notifications(self):
         """
-        tbd
+        Closes the listener for device notifications/alerts.
         """
         if self._notifications:
             self._notifications.close()
 
     async def arm_away(self):
         """
-        tbd
+        Arms the device in away mode.
         """
         await self.command(G90Commands.SETHOSTSTATUS,
                            [G90ArmDisarmTypes.ARM_AWAY])
 
     async def arm_home(self):
         """
-        tbd
+        Arms the device in home mode.
         """
         await self.command(G90Commands.SETHOSTSTATUS,
                            [G90ArmDisarmTypes.ARM_HOME])
 
     async def disarm(self):
         """
-        tbd
+        Disarms the device.
         """
         await self.command(G90Commands.SETHOSTSTATUS,
                            [G90ArmDisarmTypes.DISARM])

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -405,7 +405,7 @@ class G90Alarm:
         is opened or closed (if corresponding alert is configured on the
         device).
 
-        :type: ()(idx: int, name: str, is_open: bool)
+        :type: .. py:function:: ()(idx: int, name: str, is_open: bool)
         """
         return self._door_open_close_cb
 
@@ -432,7 +432,7 @@ class G90Alarm:
         Get or set device arm/disarm callback, the callback is invoked when
         device state changes.
 
-        :type: ()(state: :class:`.G90ArmDisarmTypes`)
+        :type: .. py:function:: ()(state: :class:`.G90ArmDisarmTypes`)
         """
         return self._armdisarm_cb
 

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -368,8 +368,8 @@ class G90Alarm:
     @property
     def sensor_callback(self):
         """
-        Get or set sensor activity callback, the callback is invoked when sensor
-        activates.
+        Get or set sensor activity callback, the callback is invoked when
+        sensor activates.
 
         :type: .. py:function:: ()(idx, name, occupancy)
         """

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -253,7 +253,9 @@ class G90Alarm:
     @property
     async def alert_config(self):
         """
-        Retrieves the alert configuration from the device.
+        Retrieves the alert configuration from the device. Please note the
+        configuration is cached upon first call, so you need to re-instantiate
+        the class to reflect any updates there.
 
         :return: Instance of :class:`.G90AlertConfig` containing the alerts
          configured

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-Provides interface to G90 Alarm panel.
+Provides interface to G90 alarm panel.
 
 .. note:: Only protocol 1.2 is supported!
 

--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Provides support for basic commands of G90 alarm panel.
 """
 
 import logging

--- a/src/pyg90alarm/callback.py
+++ b/src/pyg90alarm/callback.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Implements callbacks.
 """
 
 import asyncio

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -56,7 +56,12 @@ class G90Commands(IntEnum):
     # History
     GETHISTORY = 200
     # Sensors
-    GETSENSORLIST = 102
+    GETSENSORLIST = (102,
+    """
+        Get list of sensors
+
+        .. note:: Paginated command, see :py:class:`.G90PaginatedResult`
+    """)
     SETSINGLESENSOR = 103
     DELSENSOR = 131
     ADDSENSOR = 156
@@ -68,7 +73,11 @@ class G90Commands(IntEnum):
     REGDEVICE = 135
     DELDEVICE = 136
     CONTROLDEVICE = 137
-    GETDEVICELIST = 138
+    GETDEVICELIST = (138, """
+        Get list of devices (switches)
+
+        .. note:: Paginated command, see :py:class:`.G90PaginatedResult`
+    """)
     GETSINGLEDEVICE = 139
     SETSINGLEDEVICE = 140
     DELALLDEVICES = 203
@@ -97,7 +106,11 @@ class G90Commands(IntEnum):
     ADDSCENE = 143
     DELSCENE = 144
     CTLSCENE = 145
-    GETSCENELIST = 146
+    GETSCENELIST = (146, """
+        Get list of scenes
+
+        .. note:: Paginated command, see :py:class:`.G90PaginatedResult`
+    """)
     GETSINGLESCENE = 147
     SETSINGLESCENE = 148
     GETROOMANDSCENE = 149
@@ -105,7 +118,11 @@ class G90Commands(IntEnum):
     # IFTTT (scenarios)
     ADDIFTTT = 150
     DELIFTTT = 151
-    GETIFTTTLIST = 152
+    GETIFTTTLIST = (152, """
+        Get list of if-then-else scenarios
+
+        .. note:: Paginated command, see :py:class:`.G90PaginatedResult`
+    """)
     GETSINGLEIFTTT = 153
     SETSINGLEIFTTT = 154
     IFTTTREQTIMERID = 164
@@ -113,7 +130,11 @@ class G90Commands(IntEnum):
     # Data CRC
     GETUSERDATACRC = 160
     # Fingerprint scanners
-    GETFPLOCKLIST = 165
+    GETFPLOCKLIST = (165, """
+        Get list of fingerprint scanners
+
+        .. note:: Paginated command, see :py:class:`.G90PaginatedResult`
+    """)
     SETFPLOCKNAME = 166
     GETFPLOCKUSERNAME = 167
     SETFPLOCKUSERNAME = 168

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Definies different constants for G90 alarm panel.
 """
 
 from enum import IntEnum

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -38,9 +38,19 @@ class G90Commands(IntEnum):
     The list consists of the entities known so far, and does not pretend to be
     comprehensive or complete.
     """
+
+    def __new__(cls, value, doc=None):
+        """
+        Allows to set the docstring along with the value to enum entry.
+        """
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+        obj.__doc__ = doc
+        return obj
+
     # Host status
-    GETHOSTSTATUS = 100
-    SETHOSTSTATUS = 101
+    GETHOSTSTATUS = (100, 'Get host status')
+    SETHOSTSTATUS = (101, 'Set host status')
     # Host info
     GETHOSTINFO = 206
     # History

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -56,8 +56,7 @@ class G90Commands(IntEnum):
     # History
     GETHISTORY = 200
     # Sensors
-    GETSENSORLIST = (102,
-    """
+    GETSENSORLIST = (102, """
         Get list of sensors
 
         .. note:: Paginated command, see :py:class:`.G90PaginatedResult`

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Implements support for notifications/alerts sent by G90 alarm panel.
 """
 
 import json

--- a/src/pyg90alarm/discovery.py
+++ b/src/pyg90alarm/discovery.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Discovers G90 alarm panels.
 """
 
 import asyncio

--- a/src/pyg90alarm/entities/__init__.py
+++ b/src/pyg90alarm/entities/__init__.py
@@ -1,0 +1,3 @@
+"""
+Implements various protocol entities for G90 alarm panel.
+"""

--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Provides interface to devices (switches) of G90 alarm panel.
 """
 
 from .sensor import G90Sensor

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Provides interface to sensors of G90 alarm panel.
 """
 
 from collections import namedtuple

--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+History protocol entity.
 """
 
 import time

--- a/src/pyg90alarm/host_info.py
+++ b/src/pyg90alarm/host_info.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Protocol entity for G90 alarm panel information.
 """
 
 from collections import namedtuple

--- a/src/pyg90alarm/host_status.py
+++ b/src/pyg90alarm/host_status.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Protocol entity for G90 alarm panel status.
 """
 
 from collections import namedtuple

--- a/src/pyg90alarm/paginated_cmd.py
+++ b/src/pyg90alarm/paginated_cmd.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Implements paginated command for G90 alarm panel protocol.
 """
 
 import logging

--- a/src/pyg90alarm/paginated_result.py
+++ b/src/pyg90alarm/paginated_result.py
@@ -19,7 +19,8 @@
 # SOFTWARE.
 
 """
-tbd
+Extends paginated command for G90 alarm panel providing convenience interface
+to work with results of paginated commands.
 """
 
 import logging

--- a/src/pyg90alarm/targeted_discovery.py
+++ b/src/pyg90alarm/targeted_discovery.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 """
-tbd
+Discovers G90 alarm panel devices with specific ID.
 """
 
 import logging

--- a/src/pyg90alarm/user_data_crc.py
+++ b/src/pyg90alarm/user_data_crc.py
@@ -19,7 +19,8 @@
 # SOFTWARE.
 
 """
-tbd
+Protocol entity for G90 alarm panel that provides checksums of different
+on-device databases.
 """
 
 from collections import namedtuple

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 	asynctest
 	pylint
 commands =
-    check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml'
+    check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,.sonarcloud.properties'
     python setup.py check -m -s
     flake8 .
     pylint src/pyg90alarm


### PR DESCRIPTION
* README.md has been extended to mention known caveats and particular steps to enable device notifications
* Sphinx:
  * Switched to RTD theme
  * README.md has been converted to RST, to ease including it into generated documentation with no extra parsers
  * Removed unnecessary extension `myst_parser`
  * Enabled linking to Python documentation (`intersphinx` extension)
  * Enabled autodocumenting Ptyhon enums (`autoenum` extension)
  * TOC has now link to README contents
* Amended protocol documentation
* Source code has been updated to document `G90Alarm` class and all modules