### PR TITLE
Fixes to tests coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ __pycache__/
 *~
 .tox
 .cache
+.DS_Store
+# Tests related
+flake8.txt
+pylint.txt
+.coverage*
+coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,22 @@ deps =
 	asynctest
 	pylint
 	coverage
+setenv =
+	# Ensure the module under test will be found under `src/` directory, in
+	# case of any test command below will attempt importing it. In particular,
+	# it helps `coverage` to recognize test traces from the module under `src/`
+	# directory and report correct (aligned with repository layout) paths, not
+	# from the module installed by `tox` in the virtual environment (the traces
+	# will be referencing `tox` specific paths, not aligned with repository)
+    PYTHONPATH = src
 commands =
     check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties'
     python setup.py check -m -s
     flake8 --output-file=flake8.txt .
     pylint --output-format=parseable --output=pylint.txt src/pyg90alarm
-    coverage run --parallel-mode -m unittest -v tests {posargs}
+	# Ensure only traces for in-repository module is processed, not for one
+	# installed by `tox` (see above for more details)
+    coverage run --source=src/pyg90alarm --parallel-mode -m unittest -v tests
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs


### PR DESCRIPTION
 * Tests: ensure the module under test will be found under `src/` directory, in case of any test command below will attempt importing it. In particular, it helps `coverage` to recognize test traces from the module under `src/` directory and report correct (aligned with repository layout) paths, not from the module installed by `tox` in the virtual environment (the traces will be referencing `tox` specific paths, not aligned with repository)
* Git: ignore files generated by tests