### PR TITLE
[Github workflow] Trigger on push to master branch. Send package version to Sonar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   release:
     types: [published]
+  push:
+    branches:
+      - main
+      - master
 
 jobs:
   tests:
@@ -29,29 +33,39 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v2
         with:
-          # Disable shallow clone for Sonar scanner, as it needs access to the history
+          # Disable shallow clone for Sonar scanner, as it needs access to the
+          # history
           fetch-depth: 0
       - name: Set Python up
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
-        run: python -m pip install --upgrade setuptools pip tox virtualenv coverage
+        run: >-
+          python -m pip install --upgrade setuptools pip tox virtualenv coverage
       - name: Run the tests
         run: tox -e ${{ matrix.toxenv }}
       - name: Combine Coverage reports
         run: coverage combine
       - name: Generage Coverage combined XML report
         run: coverage xml
+      - name: Determine package version
+        id: package-version
+        run: |
+          package_version=`python3 setup.py --version`
+          ::set-output name=VALUE::$package_version
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
+          # yamllint disable rule:line-length
           args: >-
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
             -Dsonar.organization=${{ github.repository_owner }}
+            -Dsonar.projectVersion=${{ steps.package-version.VALUE }}
+          # yamllint enable rule:line-length
 
   pypi-publish:
     name: Publish to PyPi
@@ -76,7 +90,12 @@ jobs:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish the release to PyPi
-        if: github.event_name == 'release' && github.event.action == 'published'
+        # Publish to production PyPi only happens when a release published out
+        # of the main branch
+        if: >-
+          github.event_name == 'release'
+          && github.event.action == 'published'
+          && contais(['main', 'master'], github.event.release.target_commitish)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
 * Now also triggered by a push to main (master) branch, so same steps could be run to ensure the branch is healthy (except pushing to PyPi)
 * Pushing to production PyPi is now done only for releases out of the main (master) branch
 * Added step determining Python package version being processed, and the version is then passed to Sonar - it adds a possibility to compare Sonar results across versions
 * Fixed secret name for production PyPi token (`PYPI_API_TOKEN` -> `PYPI_TOKEN`)