### PR TITLE
Error handling improvements

### DIFF
--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -22,10 +22,12 @@
 tbd
 """
 
+from __future__ import annotations
 import logging
 import json
 import asyncio
 from typing import NamedTuple
+from .exceptions import (G90Error, G90TimeoutError)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,8 +41,8 @@ class G90Header(NamedTuple):
 
     :meta private:
     """
-    code: int = None
-    data: str = None
+    code: int | None = None
+    data: str | None = None
 
 
 class G90DeviceProtocol:
@@ -84,7 +86,12 @@ class G90DeviceProtocol:
         tbd
         """
         if asyncio.isfuture(self._data) and not self._data.cancelled():
-            self._data.set_result((*addr, data))
+            try:
+                self._data.set_result((*addr, data))
+            except asyncio.exceptions.InvalidStateError as exc:
+                _LOGGER.error('Wrong state of the future %s: %s',
+                              repr(self._data), exc)
+                raise exc
 
     def error_received(self, exc):
         """
@@ -183,9 +190,9 @@ class G90BaseCommand:
         tbd
         """
         if not data.startswith('ISTART'):
-            raise Exception('Missing start marker in data')
+            raise G90Error('Missing start marker in data')
         if not data.endswith('IEND\0'):
-            raise Exception('Missing end marker in data')
+            raise G90Error('Missing end marker in data')
         payload = data[6:-5]
         _LOGGER.debug("Decoded from wire: JSON string '%s'", payload)
 
@@ -194,25 +201,25 @@ class G90BaseCommand:
             try:
                 resp = json.loads(payload)
             except json.JSONDecodeError as exc:
-                raise Exception('Unable to parse response as JSON:'
-                                f" '{payload}'") from exc
+                raise G90Error('Unable to parse response as JSON:'
+                               f" '{payload}'") from exc
 
             if not isinstance(resp, list):
-                raise Exception('Mailformed response,'
-                                f" 'list' expected: '{payload}'")
+                raise G90Error('Mailformed response,'
+                               f" 'list' expected: '{payload}'")
 
         if resp is not None:
             self._resp = G90Header(*resp)
             _LOGGER.debug('Parsed from wire: %s', self._resp)
 
             if not self._resp.code:
-                raise Exception(f"Missing code in response: '{payload}'")
+                raise G90Error(f"Missing code in response: '{payload}'")
             # Check there is data if the response is non-empty
             if not self._resp.data:
-                raise Exception(f"Missing data in response: '{payload}'")
+                raise G90Error(f"Missing data in response: '{payload}'")
 
             if self._resp.code != self._code:
-                raise Exception(
+                raise G90Error(
                     'Wrong response - received code '
                     f"{self._resp.code}, expected code {self._code}")
 
@@ -259,20 +266,23 @@ class G90BaseCommand:
                                              timeout=self._timeout)
             if protocol.future_data in done:
                 break
+            # Cancel the future to signal protocol handler it is no longer
+            # valid, the future will be re-created on next retry
+            protocol.future_data.cancel()
             if not attempts:
                 transport.close()
-                raise asyncio.TimeoutError()
+                raise G90TimeoutError()
             _LOGGER.debug('Timed out, retrying')
         transport.close()
         (host, port, data) = protocol.future_data.result()
         _LOGGER.debug('Received response from %s:%s', host, port)
         if self.host != '255.255.255.255':
             if self.host != host or host == '255.255.255.255':
-                raise Exception(f'Received response from wrong host {host},'
-                                f' expected from {self.host}')
+                raise G90Error(f'Received response from wrong host {host},'
+                               f' expected from {self.host}')
         if self.port != port:
-            raise Exception(f'Received response from wrong port {port},'
-                            f' expected from {self.port}')
+            raise G90Error(f'Received response from wrong port {port},'
+                           f' expected from {self.port}')
 
         ret = self.from_wire(data)
         self._result = ret

--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -22,11 +22,16 @@
 tbd
 """
 
-from __future__ import annotations
 import logging
 import json
 import asyncio
-from typing import NamedTuple
+# Python 3.6 has `InvalidStateError` under `asyncio.base_futures` while later
+# version have it under `asyncio.expcetions`
+try:
+    from asyncio.exceptions import InvalidStateError  # pylint:disable=E1101
+except ImportError:
+    from asyncio.base_futures import InvalidStateError
+from typing import NamedTuple, Optional
 from .exceptions import (G90Error, G90TimeoutError)
 
 
@@ -41,8 +46,8 @@ class G90Header(NamedTuple):
 
     :meta private:
     """
-    code: int | None = None
-    data: str | None = None
+    code: Optional[int] = None
+    data: Optional[str] = None
 
 
 class G90DeviceProtocol:
@@ -88,7 +93,7 @@ class G90DeviceProtocol:
         if asyncio.isfuture(self._data) and not self._data.cancelled():
             try:
                 self._data.set_result((*addr, data))
-            except asyncio.exceptions.InvalidStateError as exc:
+            except InvalidStateError as exc:
                 _LOGGER.error('Wrong state of the future %s: %s',
                               repr(self._data), exc)
                 raise exc

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -159,12 +159,24 @@ class G90DeviceNotificationProtocol:
 
         # Device notifications
         if g90_message.code == G90MessageTypes.NOTIFICATION:
-            self._handle_notification(addr, G90Notification(*g90_message.data))
+            try:
+                data = G90Notification(*g90_message.data)
+            except TypeError as exc:
+                _LOGGER.error('Bad notification received from %s:%s: %s',
+                              addr[0], addr[1], exc)
+                return
+            self._handle_notification(addr, data)
             return
 
         # Device alerts
         if g90_message.code == G90MessageTypes.ALERT:
-            self._handle_alert(addr, G90DeviceAlert(*g90_message.data))
+            try:
+                data = G90DeviceAlert(*g90_message.data)
+            except TypeError as exc:
+                _LOGGER.error('Bad alert received from %s:%s: %s',
+                              addr[0], addr[1], exc)
+                return
+            self._handle_alert(addr, data)
             return
 
         _LOGGER.warning('Unknown message received from %s:%s: %s',

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -28,7 +28,6 @@ from collections import namedtuple
 import asyncio
 from .callback import G90Callback
 from .const import (G90MessageTypes, G90NotificationTypes, G90AlertTypes)
-from .exceptions import G90Error
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,18 +143,28 @@ class G90DeviceNotificationProtocol:
                         ' type %s, data %s',
                         addr[0], addr[1], alert.type, alert)
 
-    def datagram_received(self, data, addr):
+    def datagram_received(self, data, addr):  # pylint:disable=R0911
         """
         tbd
         """
         s_data = data.decode('utf-8')
         if not s_data.endswith('\0'):
-            raise G90Error('Missing end marker in data')
+            _LOGGER.error('Missing end marker in data')
+            return
         payload = s_data[:-1]
         _LOGGER.debug('Received device message from %s:%s: %s',
                       addr[0], addr[1], payload)
-        message = json.loads(payload)
-        g90_message = G90Message(*message)
+        try:
+            message = json.loads(payload)
+            g90_message = G90Message(*message)
+        except json.JSONDecodeError as exc:
+            _LOGGER.error("Unable to parse device message '%s' as JSON: %s",
+                          payload, exc)
+            return
+        except TypeError as exc:
+            _LOGGER.error("Device message '%s' is malformed: %s",
+                          payload, exc)
+            return
 
         # Device notifications
         if g90_message.code == G90MessageTypes.NOTIFICATION:

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -28,6 +28,7 @@ from collections import namedtuple
 import asyncio
 from .callback import G90Callback
 from .const import (G90MessageTypes, G90NotificationTypes, G90AlertTypes)
+from .exceptions import G90Error
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -149,7 +150,7 @@ class G90DeviceNotificationProtocol:
         """
         s_data = data.decode('utf-8')
         if not s_data.endswith('\0'):
-            raise Exception('Missing end marker in data')
+            raise G90Error('Missing end marker in data')
         payload = s_data[:-1]
         _LOGGER.debug('Received device message from %s:%s: %s',
                       addr[0], addr[1], payload)

--- a/src/pyg90alarm/exceptions.py
+++ b/src/pyg90alarm/exceptions.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""
+Exceptions specific to G90-based alarm systems.
+"""
+
+import asyncio
+
+
+class G90Error(Exception):
+    """
+    Represents a generic exception raised by many package classes.
+    """
+
+
+class G90TimeoutError(asyncio.TimeoutError):
+    """
+    Raised when particular package class to report an operation (typically
+    device command) has timed out.
+    """

--- a/src/pyg90alarm/exceptions.py
+++ b/src/pyg90alarm/exceptions.py
@@ -32,7 +32,7 @@ class G90Error(Exception):
     """
 
 
-class G90TimeoutError(asyncio.TimeoutError):
+class G90TimeoutError(asyncio.TimeoutError):  # pylint:disable=R0903
     """
     Raised when particular package class to report an operation (typically
     device command) has timed out.

--- a/src/pyg90alarm/paginated_cmd.py
+++ b/src/pyg90alarm/paginated_cmd.py
@@ -25,6 +25,7 @@ tbd
 import logging
 from collections import namedtuple
 from .base_cmd import G90BaseCommand
+from .exceptions import G90Error
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,11 +87,11 @@ class G90PaginatedCommand(G90BaseCommand):
             page_data = data.pop(0)
             page_info = G90PaginationFields(*page_data)
         except TypeError as exc:
-            raise Exception(f'Wrong pagination data {page_data} - {str(exc)}'
-                            ) from exc
+            raise G90Error(f'Wrong pagination data {page_data} - {str(exc)}'
+                           ) from exc
         except IndexError as exc:
-            raise Exception(f"Missing pagination in response '{self._resp}'"
-                            ) from exc
+            raise G90Error(f"Missing pagination in response '{self._resp}'"
+                           ) from exc
 
         self._total = page_info.total
         self._start = page_info.start
@@ -111,7 +112,7 @@ class G90PaginatedCommand(G90BaseCommand):
                 f' received {len(data)}')
 
         if errors:
-            raise Exception('. '.join(errors))
+            raise G90Error('. '.join(errors))
 
         _LOGGER.debug('Paginated command response: '
                       'total records %s, start record %s, record count %s',

--- a/src/pyg90alarm/targeted_discovery.py
+++ b/src/pyg90alarm/targeted_discovery.py
@@ -25,6 +25,7 @@ tbd
 import logging
 from collections import namedtuple
 from .discovery import G90Discovery
+from .exceptions import G90Error
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,10 +86,10 @@ class G90TargetedDiscoveryProtocol:
             _LOGGER.debug('Received from %s:%s: %s', addr[0], addr[1], data)
             decoded = data.decode('utf-8', errors='ignore')
             if not decoded.endswith('\0'):
-                raise Exception('Invalid discovery response')
+                raise G90Error('Invalid discovery response')
             host_info = G90TargetedDiscoveryInfo(*decoded[:-1].split(','))
             if host_info.message != 'IWTAC_PROBE_DEVICE_ACK':
-                raise Exception('Invalid discovery response')
+                raise G90Error('Invalid discovery response')
             res = {'guid': self._device_id,
                    'host': addr[0],
                    'port': addr[1]}

--- a/tests/test_base_commands.py
+++ b/tests/test_base_commands.py
@@ -1,11 +1,11 @@
-import asyncio
 import sys
 from .fixtures import G90Fixture
 sys.path.extend(['src', '../src'])
 
-from pyg90alarm.base_cmd import (   # noqa:E402
+from pyg90alarm.base_cmd import (  # noqa:E402
     G90BaseCommand
 )
+from pyg90alarm.exceptions import (G90Error, G90TimeoutError)  # noqa:E402
 
 
 class TestG90BaseCommand(G90Fixture):
@@ -14,7 +14,7 @@ class TestG90BaseCommand(G90Fixture):
             host='mocked', port=12345, code=206, sock=self.socket_mock)
         self.socket_mock.recvfrom.side_effect = OSError('Host unreachable')
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(OSError) as cm:
             await g90.process()
         self.assertIn("Host unreachable", cm.exception.args)
 
@@ -24,7 +24,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTARTIEND\0', ('another_host', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Received response from wrong host another_host,'
                       ' expected from mocked', cm.exception.args)
@@ -35,7 +35,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTARTIEND\0', ('mocked', 54321))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Received response from wrong port 54321,'
                       ' expected from 12345', cm.exception.args)
@@ -46,7 +46,7 @@ class TestG90BaseCommand(G90Fixture):
             timeout=0.1, retries=2, sock=self.socket_mock)
         self.socket_mock.recvfrom.return_value = (b'', ('mocked', 12345))
 
-        with self.assertRaises(asyncio.TimeoutError):
+        with self.assertRaises(G90TimeoutError):
             await g90.process()
         self.assert_callargs_on_sent_data([
             b'ISTART[206,206,""]IEND\0',
@@ -59,7 +59,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn("Unable to parse response as JSON: '['",
                       cm.exception.args)
@@ -70,7 +70,7 @@ class TestG90BaseCommand(G90Fixture):
             host='mocked', port=12345, code=206, sock=self.socket_mock)
         self.socket_mock.recvfrom.return_value = (b'', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Missing start marker in data', cm.exception.args)
         self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])
@@ -90,7 +90,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[]IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn("Missing code in response: '[]'", cm.exception.args)
         self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])
@@ -101,7 +101,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[206]IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn("Missing data in response: '[206]'",
                       cm.exception.args)
@@ -113,7 +113,7 @@ class TestG90BaseCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[206,[]]IEND', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Missing end marker in data', cm.exception.args)
         self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])

--- a/tests/test_base_commands.py
+++ b/tests/test_base_commands.py
@@ -95,6 +95,18 @@ class TestG90BaseCommand(G90Fixture):
         self.assertIn("Missing code in response: '[]'", cm.exception.args)
         self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])
 
+    async def test_wrong_code_response(self):
+        g90 = G90BaseCommand(
+            host='mocked', port=12345, code=206, sock=self.socket_mock)
+        self.socket_mock.recvfrom.return_value = (
+            b'ISTART[106,[""]]IEND\0', ('mocked', 12345))
+
+        with self.assertRaises(G90Error) as cm:
+            await g90.process()
+        self.assertIn('Wrong response - received code 106, expected code 206',
+                      cm.exception.args)
+        self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])
+
     async def test_no_data_response(self):
         g90 = G90BaseCommand(
             host='mocked', port=12345, code=206, sock=self.socket_mock)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -65,3 +65,22 @@ class TestG90TargetedDiscovery(G90Fixture):
         self.assertEqual(discovered[0]['host'], 'mocked')
         self.assertEqual(discovered[0]['port'], 12345)
         self.assert_callargs_on_sent_data([b'IWTAC_PROBE_DEVICE,DUMMYGUID\0'])
+
+    async def test_targeted_discovery_wrong_response_start_marker(self):
+        data = b'IWTAC_PROBE_DEVICE_ACK_BAD,TSV018-3SIA' \
+               b',1.2,1.1,206,1.8,3,3,1,0,2,50,100\0'
+
+        g90 = G90TargetedDiscovery(
+            device_id='DUMMYGUID',
+            host='255.255.255.255',
+            port=REMOTE_TARGETED_DISCOVERY_PORT,
+            local_port=LOCAL_TARGETED_DISCOVERY_PORT,
+            timeout=0.1, sock=self.socket_mock)
+        self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
+
+        with self.assertLogs(level='WARNING') as cm:
+            await g90.process()
+            self.assertEqual(cm.output, [
+                'WARNING:pyg90alarm.targeted_discovery:'
+                'Got exception, ignoring: Invalid discovery response'
+            ])

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -84,3 +84,22 @@ class TestG90TargetedDiscovery(G90Fixture):
                 'WARNING:pyg90alarm.targeted_discovery:'
                 'Got exception, ignoring: Invalid discovery response'
             ])
+
+    async def test_targeted_discovery_wrong_response_end_marker(self):
+        data = b'IWTAC_PROBE_DEVICE_ACK,TSV018-3SIA' \
+               b',1.2,1.1,206,1.8,3,3,1,0,2,50,100'
+
+        g90 = G90TargetedDiscovery(
+            device_id='DUMMYGUID',
+            host='255.255.255.255',
+            port=REMOTE_TARGETED_DISCOVERY_PORT,
+            local_port=LOCAL_TARGETED_DISCOVERY_PORT,
+            timeout=0.1, sock=self.socket_mock)
+        self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
+
+        with self.assertLogs(level='WARNING') as cm:
+            await g90.process()
+            self.assertEqual(cm.output, [
+                'WARNING:pyg90alarm.targeted_discovery:'
+                'Got exception, ignoring: Invalid discovery response'
+            ])

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -10,6 +10,53 @@ from pyg90alarm.device_notifications import (   # noqa:E402
 
 
 class TestG90Notifications(G90Fixture):
+    async def test_unknown_bad_notification(self):
+        def sock_data_awaitable(*args):
+            future.set_result(True)
+            return b'[170,[1]]\0', ('mocked', 12345)
+
+        future = self.loop.create_future()
+        notifications = G90DeviceNotifications(sock=self.socket_mock)
+        await notifications.listen()
+        self.socket_mock.recvfrom.side_effect = sock_data_awaitable
+        asynctest.set_read_ready(self.socket_mock, self.loop)
+        with self.assertLogs(level='ERROR') as cm:
+            await asyncio.wait([future], timeout=0.1)
+            self.assertIn(cm.output[0], [
+                'ERROR:pyg90alarm.device_notifications:'
+                'Bad notification received from mocked:12345:'
+                " <lambda>() missing 1 required positional argument: 'data'",
+                'ERROR:pyg90alarm.device_notifications:'
+                'Bad notification received from mocked:12345:'
+                " __new__() missing 1 required positional argument: 'data'",
+            ])
+        notifications.close()
+
+    async def test_bad_device_alert(self):
+        def sock_data_awaitable(*args):
+            future.set_result(True)
+            return (b'[208,[]]\0', ('mocked', 12345))
+        future = self.loop.create_future()
+        notifications = G90DeviceNotifications(sock=self.socket_mock)
+        await notifications.listen()
+        self.socket_mock.recvfrom.side_effect = sock_data_awaitable
+        asynctest.set_read_ready(self.socket_mock, self.loop)
+        with self.assertLogs(level='ERROR') as cm:
+            await asyncio.wait([future], timeout=0.1)
+            self.assertIn(cm.output[0], [
+                'ERROR:pyg90alarm.device_notifications:'
+                'Bad alert received from mocked:12345:'
+                " <lambda>() missing 9 required positional arguments: 'type',"
+                " 'event_id', 'resv2', 'resv3', 'zone_name', 'device_id',"
+                " 'unix_time', 'resv4', and 'other'",
+                'ERROR:pyg90alarm.device_notifications:'
+                'Bad alert received from mocked:12345:'
+                " __new__() missing 9 required positional arguments: 'type',"
+                " 'event_id', 'resv2', 'resv3', 'zone_name', 'device_id',"
+                " 'unix_time', 'resv4', and 'other'",
+            ])
+        notifications.close()
+
     async def test_unknown_device_notification(self):
         def sock_data_awaitable(*args):
             future.set_result(True)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,11 +22,15 @@ class TestG90Notifications(G90Fixture):
         asynctest.set_read_ready(self.socket_mock, self.loop)
         with self.assertLogs(level='ERROR') as cm:
             await asyncio.wait([future], timeout=0.1)
-            self.assertEqual(
-                cm.output[0],
-                'ERROR:pyg90alarm.device_notifications:Device message'
-                " '[170]' is malformed: <lambda>() missing 1 required"
-                " positional argument: 'data'"
+            self.assertIn(
+                cm.output[0], [
+                    'ERROR:pyg90alarm.device_notifications:Device message'
+                    " '[170]' is malformed: <lambda>() missing 1 required"
+                    " positional argument: 'data'",
+                    'ERROR:pyg90alarm.device_notifications:Device message'
+                    " '[170]' is malformed: __new__() missing 1 required"
+                    " positional argument: 'data'",
+                ]
             )
         notifications.close()
 

--- a/tests/test_paginated_commands.py
+++ b/tests/test_paginated_commands.py
@@ -5,6 +5,7 @@ sys.path.extend(['src', '../src'])
 from pyg90alarm.paginated_cmd import (   # noqa:E402
     G90PaginatedCommand,
 )
+from pyg90alarm.exceptions import G90Error  # noqa:E402
 
 
 class TestG90PaginatedCommand(G90Fixture):
@@ -16,7 +17,7 @@ class TestG90PaginatedCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[102,[[]]]IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception, ) as cm:
+        with self.assertRaises(G90Error, ) as cm:
             await g90.process()
         self.assertIn(cm.exception.args[0],
                       ['Wrong pagination data [] -'
@@ -37,7 +38,7 @@ class TestG90PaginatedCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[102,[[1,1,1]]]IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Truncated data provided in paginated response -'
                       ' expected 1 entities as per response, received 0',
@@ -65,7 +66,7 @@ class TestG90PaginatedCommand(G90Fixture):
         self.socket_mock.recvfrom.return_value = (
             b'ISTART[102,[[2,1,2],[""],[""]]]IEND\0', ('mocked', 12345))
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(G90Error) as cm:
             await g90.process()
         self.assertIn('Extra data provided in paginated response -'
                       ' expected 1 entities as per request, received 2',

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,15 @@ setenv =
 	# from the module installed by `tox` in the virtual environment (the traces
 	# will be referencing `tox` specific paths, not aligned with repository)
     PYTHONPATH = src
+allowlist_externals =
+	cat
 commands =
     check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties'
     python setup.py check -m -s
-    flake8 --output-file=flake8.txt .
+    flake8 --tee --output-file=flake8.txt .
     pylint --output-format=parseable --output=pylint.txt src/pyg90alarm
+	# Show the `pylint` report to the standard output, to ease fixing the issues reported
+	cat pylint.txt
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     coverage run --source=src/pyg90alarm --parallel-mode -m unittest -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -34,11 +34,12 @@ commands =
     python setup.py check -m -s
     flake8 --tee --output-file=flake8.txt .
     pylint --output-format=parseable --output=pylint.txt src/pyg90alarm
-	# Show the `pylint` report to the standard output, to ease fixing the issues reported
-	cat pylint.txt
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
     coverage run --source=src/pyg90alarm --parallel-mode -m unittest -v tests
+commands_post =
+	# Show the `pylint` report to the standard output, to ease fixing the issues reported
+	cat pylint.txt
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs


### PR DESCRIPTION
* `G90BaseCommand`: Cancel the future upon command timed out, to signal  protocol handler it is no longer valid, the future will be re-created on next retry. The future is used to retrieve the command response from the async protocol handler
* `src/pyg90alarm/base_cmd.py`: Linting fixes to type hints
* `G90DeviceProtocol`: log error with additional information if the future used to pass the response to the caller is in invalid state
* Introduced `exceptions.G90Error` and `exceptions.G90TimeoutError` to report exceptions specific to the package classes
* `G90DeviceNotificationProtocol`: Improved overall error reporting - all issues processing device messages are now logged and the message discarded, instead of raising an exception from protocol handler.
* `G90DeviceNotificationProtocol`: Added dedicated errors when device message is an invalid JSON or missing message header
* Improved tests coverage