### PR TITLE
Support for arm/disarm device alerts

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -54,6 +54,7 @@ from .const import (
     G90Commands, REMOTE_PORT,
     REMOTE_TARGETED_DISCOVERY_PORT,
     LOCAL_TARGETED_DISCOVERY_PORT,
+    G90ArmDisarmTypes,
 )
 from .base_cmd import G90BaseCommand
 from .paginated_result import G90PaginatedResult
@@ -398,16 +399,19 @@ class G90Alarm:
         """
         tbd
         """
-        await self.command(G90Commands.SETHOSTSTATUS, [1])
+        await self.command(G90Commands.SETHOSTSTATUS,
+                           [G90ArmDisarmTypes.ARM_AWAY])
 
     async def arm_home(self):
         """
         tbd
         """
-        await self.command(G90Commands.SETHOSTSTATUS, [2])
+        await self.command(G90Commands.SETHOSTSTATUS,
+                           [G90ArmDisarmTypes.ARM_HOME])
 
     async def disarm(self):
         """
         tbd
         """
-        await self.command(G90Commands.SETHOSTSTATUS, [3])
+        await self.command(G90Commands.SETHOSTSTATUS,
+                           [G90ArmDisarmTypes.DISARM])

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -130,6 +130,17 @@ class G90NotificationTypes(IntEnum):
     SENSOR_ACTIVITY = 5
 
 
+class G90ArmDisarmTypes(IntEnum):
+    """
+    Defines arm/disarm states of the device, applicable both for setting device
+    state and one the device sends in notification messages.
+    """
+    ARM_AWAY = 1
+    ARM_HOME = 2
+    DISARM = 3
+    ALARMED = 4
+
+
 class G90AlertTypes(IntEnum):
     """
     Defines types of alerts sent by the alarm panel.
@@ -137,3 +148,17 @@ class G90AlertTypes(IntEnum):
     STATE_CHANGE = 2
     ALARM = 3
     DOOR_OPEN_CLOSE = 4
+
+
+class G90AlertStateChangeTypes(IntEnum):
+    """
+    Defines types of alert for device state changes.
+    """
+    AC_POWER_FAILURE = 1
+    AC_POWER_RECOVER = 2
+    DISARM = 3
+    ARM_AWAY = 4
+    ARM_HOME = 5
+    LOW_BATTERY = 6
+    WIFI_CONNECTED = 7
+    WIFI_DISCONNECTED = 8


### PR DESCRIPTION
* Introduced `G90ArmDisarmTypes` and `G90AlertStateChangeTypes` enums,  defining numeric states for arming/disarming the panel and those sent  in device messages for state changes, respectively
 * `G90Alarm`: use newly introduces `G90ArmDisarmTypes` enum instead of  hardcoded values for `arm_away()`, `arm_home()` and `disarm` methods
 * `G90DeviceNotificationProtocol` has been extended to handle alert for  device state changes, only those relevant to arm/disarm alerts. Those  alerts will trigger invoking `armdisarm_cb` same way as it's done for  notificaitons from the device. Although it might trigger multiple callback invocation it should be safe as same state will be passed to those across multiple calls
