### PR TITLE
Exception reporting in callbacks.  Cached alert config

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -108,6 +108,7 @@ class G90Alarm:
         self._armdisarm_cb = None
         self._door_open_close_cb = None
         self._reset_occupancy_interval = reset_occupancy_interval
+        self._alert_config = None
 
     async def command(self, code, data=None):
         """
@@ -225,8 +226,10 @@ class G90Alarm:
         :return: Instance of :class:`.G90AlertConfig` containing the alerts
          configured
         """
-        res = await self.command(G90Commands.GETNOTICEFLAG)
-        return G90AlertConfig(*res)
+        if not self._alert_config:
+            res = await self.command(G90Commands.GETNOTICEFLAG)
+            self._alert_config = G90AlertConfig(*res)
+        return self._alert_config
 
     @property
     async def user_data_crc(self):

--- a/src/pyg90alarm/callback.py
+++ b/src/pyg90alarm/callback.py
@@ -72,8 +72,9 @@ class G90Callback:
             exc = task.exception()
             if exc:
                 _LOGGER.error('Got exception when invoking'
-                              " callback '%s(...)': %s",
-                              task.get_coro().__qualname__, exc)
+                              " callback '%s(...)':",
+                              task.get_coro().__qualname__,
+                              exc_info=exc, stack_info=False)
 
         task.add_done_callback(reap_callback_exception)
 


### PR DESCRIPTION
* Added code to log exception information (if any) during callback  processing
* G90Alarm: alarm_config property is now cached to reduce number of device calls during notification/alert processing (e. g. sensor ones, those might be frequent resulting in notable amount of calls)