### PR TITLE
Option to have SMS alerts enabled only from device is armed

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -510,11 +510,6 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
         await self.command(G90Commands.SETHOSTSTATUS,
                            [state])
 
-        # Invoke corresponding callback in case the device notifications aren't
-        # available, at the cost of possible duplicate callback invocation if
-        # they are.
-        await self._internal_armdisarm_cb(state)
-
     async def arm_home(self):
         """
         Arms the device in home mode.
@@ -523,9 +518,6 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
         await self.command(G90Commands.SETHOSTSTATUS,
                            [state])
 
-        # See the clarification above.
-        await self._internal_armdisarm_cb(state)
-
     async def disarm(self):
         """
         Disarms the device.
@@ -533,9 +525,6 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
         state = G90ArmDisarmTypes.DISARM
         await self.command(G90Commands.SETHOSTSTATUS,
                            [state])
-
-        # See the clarification above.
-        await self._internal_armdisarm_cb(state)
 
     @property
     def sms_alert_when_armed(self):

--- a/src/pyg90alarm/callback.py
+++ b/src/pyg90alarm/callback.py
@@ -93,9 +93,9 @@ class G90Callback:
 
 def async_as_sync(func):
     """
-    Invokes an async function as regular one via :py:func:`G90Callback.invoke`. One of
-    possible use cases is implementing property setter for async code, where
-    the function could be used an decorator:
+    Invokes an async function as regular one via :py:func:`G90Callback.invoke`.
+    One of possible use cases is implementing property setter for async code,
+    where the function could be used an decorator:
 
     .. code-block:: python
 

--- a/src/pyg90alarm/callback.py
+++ b/src/pyg90alarm/callback.py
@@ -89,3 +89,30 @@ class G90Callback:
             # Python 3.6 has no `get_running_loop`, only `get_event_loop`
             loop = asyncio.get_event_loop()
         loop.call_later(delay, partial(callback, *args, **kwargs))
+
+
+def async_as_sync(func):
+    """
+    Invokes an async function as regular one via :py:func:`G90Callback.invoke`. One of
+    possible use cases is implementing property setter for async code, where
+    the function could be used an decorator:
+
+    .. code-block:: python
+
+     @property
+     async def a_property(...):
+         ...
+
+     @a_property.setter
+     @async_as_sync
+     async def a_property(...):
+         ...
+
+    Since the function internally submits the wrapped async code as
+    :py:mod:`asyncio` task, it execution isn't guaranteed as the program could
+    be terminated earlier that it is processed in the loop.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return G90Callback.invoke(func, *args, **kwargs)
+    return wrapper

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from .test_paginated_commands import *  # noqa: F401,F403
 from .test_discovery import *  # noqa: F401,F403
 from .test_notifications import *  # noqa: F401,F403
 from .test_alarm import *  # noqa: F401, F403
+from .test_callback import *  # noqa: F401, F403
 
 if __name__ == '__main__':
     unittest.main(verbosity=3)

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,6 +1,7 @@
 import asyncio
 import socket
 import sys
+import logging
 from unittest.mock import MagicMock
 import asynctest
 from .fixtures import G90Fixture
@@ -26,7 +27,11 @@ from pyg90alarm.host_status import (   # noqa:E402
 from pyg90alarm.user_data_crc import (   # noqa:E402
     G90UserDataCRC,
 )
-from pyg90alarm.config import G90AlertConfig  # noqa: E402
+from pyg90alarm.config import (  # noqa: E402
+    G90AlertConfigFlags,
+)
+
+logging.basicConfig()
 
 
 class TestG90Alarm(G90Fixture):
@@ -352,4 +357,91 @@ class TestG90Alarm(G90Fixture):
 
         res = await g90.alert_config
         self.assert_callargs_on_sent_data([b'ISTART[117,117,""]IEND\0'])
-        self.assertIsInstance(res, G90AlertConfig)
+        self.assertIsInstance(res, G90AlertConfigFlags)
+
+    async def test_set_alert_config(self):
+        """ Tests for setting alert configuration to the the device """
+        g90 = G90Alarm(host="mocked", port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (b"ISTART[117,[1]]IEND\0", ("mocked", 12345)),
+            (b"ISTART[117,[3]]IEND\0", ("mocked", 12345)),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+
+        await g90.set_alert_config(
+            await g90.alert_config
+            | G90AlertConfigFlags.AC_POWER_FAILURE  # noqa:W503
+            | G90AlertConfigFlags.HOST_LOW_VOLTAGE  # noqa:W503
+        )
+        self.assert_callargs_on_sent_data(
+            [
+                b'ISTART[117,117,""]IEND\0',
+                b'ISTART[117,117,""]IEND\0',
+                b"ISTART[116,116,[116,[9]]]IEND\0",
+            ]
+        )
+
+    async def test_sms_alert_when_armed(self):
+        """ Tests for enabling SMS alerts when device is armed """
+        future = self.loop.create_future()
+        armdisarm_cb = MagicMock()
+        armdisarm_cb.side_effect = lambda *args: future.set_result(True)
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        g90.armdisarm_callback = armdisarm_cb
+        g90.sms_alert_when_armed = True
+        socket_ntfy_mock = asynctest.SocketMock()
+        socket_ntfy_mock.type = socket.SOCK_DGRAM
+        await g90.listen_device_notifications(socket_ntfy_mock)
+        asynctest.set_read_ready(socket_ntfy_mock, self.loop)
+        self.socket_mock.recvfrom.side_effect = [
+            # First command to get alert configuration is from
+            # `G90Alarm.alert_config` property
+            (b"ISTART[117,[1]]IEND\0", ("mocked", 12345)),
+            # Second command for same is invoked by `G90Alarm.set_alert_config`
+            # that checks if alert config has been modified externally
+            (b"ISTART[117,[1]]IEND\0", ("mocked", 12345)),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+        socket_ntfy_mock.recvfrom.side_effect = [
+            (b'[170,[1,[1]]]\0', ('mocked', 12345)),
+        ]
+        await asyncio.wait([future], timeout=0.1)
+        g90.close_device_notifications()
+        self.assert_callargs_on_sent_data(
+            [
+                b'ISTART[117,117,""]IEND\0',
+                b'ISTART[117,117,""]IEND\0',
+                b"ISTART[116,116,[116,[513]]]IEND\0",
+            ]
+        )
+
+    async def test_sms_alert_when_disarmed(self):
+        """ Tests for disabling SMS alerts when device is disarmed """
+        future = self.loop.create_future()
+        armdisarm_cb = MagicMock()
+        armdisarm_cb.side_effect = lambda *args: future.set_result(True)
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        g90.armdisarm_callback = armdisarm_cb
+        g90.sms_alert_when_armed = True
+        socket_ntfy_mock = asynctest.SocketMock()
+        socket_ntfy_mock.type = socket.SOCK_DGRAM
+        await g90.listen_device_notifications(socket_ntfy_mock)
+        asynctest.set_read_ready(socket_ntfy_mock, self.loop)
+        self.socket_mock.recvfrom.side_effect = [
+            # See above for the clarification on command sequence
+            (b"ISTART[117,[513]]IEND\0", ("mocked", 12345)),
+            (b"ISTART[117,[513]]IEND\0", ("mocked", 12345)),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+        socket_ntfy_mock.recvfrom.side_effect = [
+            (b'[170,[1,[3]]]\0', ('mocked', 12345)),
+        ]
+        await asyncio.wait([future], timeout=0.1)
+        g90.close_device_notifications()
+        self.assert_callargs_on_sent_data(
+            [
+                b'ISTART[117,117,""]IEND\0',
+                b'ISTART[117,117,""]IEND\0',
+                b"ISTART[116,116,[116,[1]]]IEND\0",
+            ]
+        )

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,7 +1,6 @@
 import asyncio
 import socket
 import sys
-import logging
 from unittest.mock import MagicMock
 import asynctest
 from .fixtures import G90Fixture

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -31,8 +31,6 @@ from pyg90alarm.config import (  # noqa: E402
     G90AlertConfigFlags,
 )
 
-logging.basicConfig()
-
 
 class TestG90Alarm(G90Fixture):
     async def test_host_status(self):

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,0 +1,29 @@
+import asyncio
+import sys
+from .fixtures import G90Fixture
+from pyg90alarm.callback import (   # noqa:E402
+    async_as_sync,
+)
+sys.path.extend(['src', '../src'])
+
+
+class TestG90Callback(G90Fixture):
+    async def test_async_as_sync_decorator(self):
+        """ Tests for `async_as_sync` decorator """
+        class TestProperty:
+            _prop = None
+
+            @property
+            async def test_property(self):
+                return self._prop
+
+            @test_property.setter
+            @async_as_sync
+            async def test_property(self, value):
+                self._prop = value
+
+        test_instance = TestProperty()
+        test_instance.test_property = 'test value'
+        # Allow the async task the decorator submits to finish
+        await asyncio.sleep(0)
+        self.assertEqual(await test_instance.test_property, 'test value')


### PR DESCRIPTION
* `G90Alarm`: added `sms_alert_when_armed` property that allows to save costs on SMS enabling corresponding alerts only when device is armed.
* `G90Alarm`: property `alert_config` now returns `G90AlertConfigFlags` directly, to skip unnecessary reference to `G90AlertConfig.flags`
* Added `async_as_sync` decorator that allows using async property setter. Please note since the function internally submits the wrapped  async code as `asyncio` task, it execution isn't guaranteed as the program could be terminated earlier that it is processed in the loop.