### PR TITLE
`G90alarm.set_alert_config`: update stored alert configuration

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -293,6 +293,8 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
                 str(alert_config), str(value)
             )
         await self.command(G90Commands.SETNOTICEFLAG, [value])
+        # Update the alert configuration stored
+        self._alert_config = value
 
     @property
     async def user_data_crc(self):

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -377,6 +377,12 @@ class TestG90Alarm(G90Fixture):
                 b"ISTART[116,116,[116,[9]]]IEND\0",
             ]
         )
+        # Validate we retrieve same alert configuration just has been set
+        self.assertEqual(
+            await g90.alert_config,
+            G90AlertConfigFlags.AC_POWER_FAILURE
+            | G90AlertConfigFlags.HOST_LOW_VOLTAGE  # noqa:W503
+        )
 
     async def test_sms_alert_when_armed(self):
         """ Tests for enabling SMS alerts when device is armed """


### PR DESCRIPTION
* `G90alarm.set_alert_config`: update stored alert configuration upon setting it to device, so next time `alert_config` property is read it  will return the value has been set - currently it falsely logs a message about the configuration has been changed externally