### PR TITLE
`G90HostInfoWifiStatus` enum: `NO_SIGNAL` entry

### DIFF
--- a/src/pyg90alarm/host_info.py
+++ b/src/pyg90alarm/host_info.py
@@ -58,6 +58,7 @@ class G90HostInfoWifiStatus(IntEnum):
     """
     POWERED_OFF = 0
     NOT_CONNECTED = 1
+    NO_SIGNAL = 2
     OPERATIONAL = 3
 
 


### PR DESCRIPTION
* `G90HostInfoWifiStatus` enum: added `NO_SIGNAL` entry