### PR TITLE
Support for enabling/disabling sensors

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -128,7 +128,7 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
 
     def paginated_result(self, code, start=1, end=None):
         """
-        Returns asynchronous generator to for a paginated command, that is -
+        Returns asynchronous generator for a paginated command, that is -
         command operating on a range of records.
 
         :param code: Command code
@@ -136,7 +136,8 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
         :param int start: Starting record position (one-based)
         :param int end: Ending record position (one-based)
         :return: :class:`.G90PaginatedResult` being asynchronous generator
-          over the result of command invocation
+          over the result of command invocation. Each access to the generator
+          yields :class:`.G90PaginatedResponse` instance
         """
         return G90PaginatedResult(
             self._host, self._port, code, start, end, sock=self._sock

--- a/src/pyg90alarm/definitions/__init__.py
+++ b/src/pyg90alarm/definitions/__init__.py
@@ -1,0 +1,3 @@
+"""
+Contains various defintiions for G90 devices (sensors etc.)
+"""

--- a/src/pyg90alarm/definitions/__init__.py
+++ b/src/pyg90alarm/definitions/__init__.py
@@ -1,3 +1,3 @@
 """
-Contains various defintiions for G90 devices (sensors etc.)
+Contains various definitions for G90 devices (sensors etc.)
 """

--- a/src/pyg90alarm/definitions/sensors.py
+++ b/src/pyg90alarm/definitions/sensors.py
@@ -1,0 +1,618 @@
+# Copyright (c) 2022 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Sensor definitions for G90 devices, required when modifying them since writing
+a sensor to the device requires values not present on read.
+"""
+from collections import namedtuple
+from enum import IntEnum
+
+
+class SensorMatchMode(IntEnum):
+    """
+    Defines compare (match) mode for the sensor.
+    """
+    ALL = 0
+    ONLY20BITS = 1
+    ONLY16BITS = 2
+
+
+class SensorRwMode(IntEnum):
+    """
+    Defines read/write mode for the sensor.
+    """
+    READ = 0
+    WRITE = 1
+    READ_WRITE = 2
+
+
+class SensorDefinition(
+    namedtuple(
+        'SensorDefinition', [
+            'type', 'subtype', 'rx', 'tx',
+            'private_data', 'rwMode', 'matchMode',
+        ]
+    )
+):
+    """
+    Holds sensor definition data.
+    """
+    @property
+    def reserved_data(self):
+        """
+        Returns sensor 'reserved_data' field to be written, combined of match
+        and RW mode values bitwise.
+        """
+        return self.matchMode.value << 4 | self.rwMode.value
+
+
+SENSOR_DEFINITIONS = [
+    # Cord Door Sensor
+    SensorDefinition(
+        type=126,
+        subtype=1,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Glass Sensor
+    SensorDefinition(
+        type=126,
+        subtype=2,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Gas Sensor
+    SensorDefinition(
+        type=126,
+        subtype=3,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Smoke Sensor
+    SensorDefinition(
+        type=126,
+        subtype=4,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord SOS Sensor
+    SensorDefinition(
+        type=126,
+        subtype=5,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Vibration Sensor
+    SensorDefinition(
+        type=126,
+        subtype=6,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Water Sensor
+    SensorDefinition(
+        type=126,
+        subtype=7,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Beam Sensor
+    SensorDefinition(
+        type=126,
+        subtype=9,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord PIR motion sensor
+    SensorDefinition(
+        type=126,
+        subtype=8,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord RFID Sensor
+    SensorDefinition(
+        type=126,
+        subtype=11,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Bell Sensor
+    SensorDefinition(
+        type=126,
+        subtype=12,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Cord Device
+    SensorDefinition(
+        type=254,
+        subtype=0,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket S07
+    SensorDefinition(
+        type=128,
+        subtype=3,
+        rx=0,
+        tx=2,
+        private_data='060A0600',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket JDQ
+    SensorDefinition(
+        type=128,
+        subtype=0,
+        rx=0,
+        tx=2,
+        private_data='0707070B0B0D0D0E0E00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket Relay (single channel)
+    SensorDefinition(
+        type=128,
+        subtype=1,
+        rx=0,
+        tx=2,
+        private_data='07070700',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket Switch
+    SensorDefinition(
+        type=128,
+        subtype=4,
+        rx=0,
+        tx=2,
+        private_data='050D0500',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket Switch (3 channel)
+    SensorDefinition(
+        type=128,
+        subtype=5,
+        rx=0,
+        tx=2,
+        private_data='070A0E080D060B00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket Switch (4 channel)
+    SensorDefinition(
+        type=128,
+        subtype=6,
+        rx=0,
+        tx=2,
+        private_data='0B0D0E0B0C090A070800',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Rolling curtain
+    SensorDefinition(
+        type=130,
+        subtype=0,
+        rx=0,
+        tx=7,
+        private_data='070B0E0D0C09030100',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Curtain
+    SensorDefinition(
+        type=130,
+        subtype=1,
+        rx=0,
+        tx=7,
+        private_data='0804010200',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Sliding window
+    SensorDefinition(
+        type=130,
+        subtype=1,
+        rx=0,
+        tx=7,
+        private_data='0E0B0E0D0C09030100',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Push Window curtain
+    SensorDefinition(
+        type=130,
+        subtype=2,
+        rx=0,
+        tx=7,
+        private_data='070B0E0D0C09030100',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Air Conditioner
+    SensorDefinition(
+        type=133,
+        subtype=0,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # TV
+    SensorDefinition(
+        type=135,
+        subtype=0,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Infrared Transcoder
+    SensorDefinition(
+        type=145,
+        subtype=0,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Siren SS08
+    SensorDefinition(
+        type=129,
+        subtype=0,
+        rx=0,
+        tx=2,
+        private_data='FEFEF600',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Siren SS07A
+    SensorDefinition(
+        type=129,
+        subtype=4,
+        rx=0,
+        tx=2,
+        private_data='FEFEF600',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Siren SS04
+    SensorDefinition(
+        type=129,
+        subtype=5,
+        rx=0,
+        tx=2,
+        private_data='FCFCCF00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Siren SS02B
+    SensorDefinition(
+        type=129,
+        subtype=1,
+        rx=0,
+        tx=2,
+        private_data='FCFCCF00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Solar-powered siren
+    SensorDefinition(
+        type=129,
+        subtype=2,
+        rx=0,
+        tx=2,
+        private_data='FEFEFD00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Night Light
+    SensorDefinition(
+        type=138,
+        subtype=0,
+        rx=0,
+        tx=2,
+        private_data='060A0600',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Socket_2.4G
+    SensorDefinition(
+        type=140,
+        subtype=1,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Siren_2.4G
+    SensorDefinition(
+        type=141,
+        subtype=1,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Switch 2.4G Type 2
+    SensorDefinition(
+        type=142,
+        subtype=2,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Switch 2.4G Type 1
+    SensorDefinition(
+        type=143,
+        subtype=1,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Switch 2.4G Type 2
+    SensorDefinition(
+        type=143,
+        subtype=2,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Switch 2.4G Type 3
+    SensorDefinition(
+        type=143,
+        subtype=3,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Switch 2.4G Type 4
+    SensorDefinition(
+        type=143,
+        subtype=4,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Curtain 2.4G
+    SensorDefinition(
+        type=144,
+        subtype=1,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.WRITE,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Door Sensor WDS07
+    SensorDefinition(
+        type=1,
+        subtype=0,
+        rx=5,
+        tx=0,
+        private_data='F100f5017d02f803f90400',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Door Sensor
+    SensorDefinition(
+        type=1,
+        subtype=1,
+        rx=2,
+        tx=0,
+        private_data='0001020400',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Door Sensor
+    SensorDefinition(
+        type=1,
+        subtype=2,
+        rx=5,
+        tx=0,
+        private_data='F100f5017d02f803f904',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # PIR motion sensor WMS08
+    SensorDefinition(
+        type=8,
+        subtype=3,
+        rx=3,
+        tx=0,
+        private_data='06000301020200',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # PIR motion sensor WMS08B
+    SensorDefinition(
+        type=8,
+        subtype=12,
+        rx=3,
+        tx=0,
+        private_data='060003010202000314',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # PIR motion sensor WMS07
+    SensorDefinition(
+        type=8,
+        subtype=2,
+        rx=3,
+        tx=0,
+        private_data='04000801020200',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Remote RMC08
+    SensorDefinition(
+        type=10,
+        subtype=1,
+        rx=4,
+        tx=0,
+        private_data='0d000b010e02070300',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Remote RMC07
+    SensorDefinition(
+        type=10,
+        subtype=0,
+        rx=4,
+        tx=0,
+        private_data='cf00fc01f3023f0300',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Remote RMC02
+    SensorDefinition(
+        type=10,
+        subtype=4,
+        rx=4,
+        tx=0,
+        private_data='cf00fc01f3023f0300',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Remote
+    SensorDefinition(
+        type=10,
+        subtype=2,
+        rx=3,
+        tx=0,
+        private_data='07000602050300',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # RFID K07
+    SensorDefinition(
+        type=11,
+        subtype=1,
+        rx=11,
+        tx=0,
+        private_data='0e0007010d020b03010402050c060a0709080809060a00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # TouchID Detector
+    SensorDefinition(
+        type=13,
+        subtype=1,
+        rx=4,
+        tx=0,
+        private_data='07000e010d020b0300',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # SOS Watch
+    SensorDefinition(
+        type=14,
+        subtype=0,
+        rx=0,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Fingerprint Lock
+    SensorDefinition(
+        type=15,
+        subtype=1,
+        rx=0,
+        tx=2,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY16BITS
+    ),
+    # Gas Detector WGD02
+    SensorDefinition(
+        type=18,
+        subtype=0,
+        rx=2,
+        tx=1,
+        private_data='09000801ff0e0e',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+    # Remote 2.4G RMC2.4G
+    SensorDefinition(
+        type=17,
+        subtype=4,
+        rx=4,
+        tx=0,
+        private_data='00',
+        rwMode=SensorRwMode.READ,
+        matchMode=SensorMatchMode.ONLY20BITS
+    ),
+]

--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -69,7 +69,7 @@ class G90Device(G90Sensor):
         """
         Changes the disabled/enabled state of the device (relay).
 
-        :param value bool: Whether to enable or disable the device
+        :param bool value: Whether to enable or disable the device
         """
         _LOGGER.warning(
             'Manipulating with enable/disable for device is unsupported'

--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -22,25 +22,55 @@
 Provides interface to devices (switches) of G90 alarm panel.
 """
 
+import logging
 from .sensor import G90Sensor
 from ..const import G90Commands
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 class G90Device(G90Sensor):
     """
-    tbd
+    Interacts with device (relay) on G90 alarm panel.
     """
 
     async def turn_on(self):
         """
-        tbd
+        Turns on the device (relay)
         """
         await self.parent.command(G90Commands.CONTROLDEVICE,
                                   [self.index, 0, self.subindex])
 
     async def turn_off(self):
         """
-        tbd
+        Turns off the device (relay)
         """
         await self.parent.command(G90Commands.CONTROLDEVICE,
                                   [self.index, 1, self.subindex])
+
+    @property
+    def supports_enable_disable(self):
+        """
+        Indicates if disabling/enabling the device (relay) is supported.
+
+        :return: Support for enabling/disabling the device
+        :rtype: bool
+        """
+        # No support for manipulating of disable/enabled for the device, since
+        # single protocol entity read from the G90 alarm panel results in
+        # multiple `G90Device` instances and changing the state would
+        # subsequently require a design change to allow multiple entities to
+        # reflect that. Multiple device entities are for multi-channel relays
+        # mostly.
+        return False
+
+    async def set_enabled(self, value):
+        """
+        Changes the disabled/enabled state of the device (relay).
+
+        :param value bool: Whether to enable or disable the device
+        """
+        _LOGGER.warning(
+            'Manipulating with enable/disable for device is unsupported'
+        )

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -188,7 +188,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     def name(self):
         """
         Returns sensor name, accounting for multi-channel entities (single
-        protocol entity results in multiple `G90Sensor` instances).
+        protocol entity results in multiple :class:`.G90Sensor` instances).
 
         :return: Sensor name
         :rtype: str

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -148,24 +148,24 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     """
     Interacts with sensor on G90 alarm panel.
 
-    :param args: Pass-through positional arguments for :class:`.G90Sensor` for
-     interpreting protocol fields
-    :param parent: Instance of :class:`..G90Alarm` the sensor is associated
+    :param args: Pass-through positional arguments for
+     :class:`.G90SensorIncomingData` for interpreting protocol fields
+    :param parent: Instance of :class:`.G90Alarm` the sensor is associated
      with
-    :type parent: :class:`..G90Alarm`
+    :type parent: :class:`.G90Alarm`
     :param subindex int: Index of the sensor within multi-channel devices
      (those having multiple nodes)
     :param proto_idx int: Index of the sensor within list of sensors as
      retrieved from the alarm panel
-    :param kwargs: Pass-through keyword arguments for :class:`.G90Sensor` for
-     interpreting protocol fields
+    :param kwargs: Pass-through keyword arguments for
+     :class:`.G90SensorIncomingData` for interpreting protocol fields
     """
     def __init__(self, *args, parent, subindex, proto_idx, **kwargs):
         self._protocol_incoming_data_kls = (
-            namedtuple('G90Sensor', INCOMING_FIELDS)
+            namedtuple('G90SensorIncomingData', INCOMING_FIELDS)
         )
         self._protocol_outgoing_data_kls = (
-            namedtuple('G90Sensor', OUTGOING_FIELDS)
+            namedtuple('G90SensorOutgoingData', OUTGOING_FIELDS)
         )
         self._protocol_data = self._protocol_incoming_data_kls(*args, **kwargs)
         self._parent = parent
@@ -188,7 +188,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     def name(self):
         """
         Returns sensor name, accounting for multi-channel entities (single
-        protocol entiry results in multiple `G90Sensor` instances).
+        protocol entity results in multiple `G90Sensor` instances).
 
         :return: Sensor name
         :rtype: str
@@ -289,11 +289,11 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     @property
     def parent(self):
         """
-        Returns parent :class:`..G90Alarm` instance the sensor is associated
+        Returns parent :class:`.G90Alarm` instance the sensor is associated
         with.
 
-        :return: Parent :class:`..G90Alarm` instance
-        :rtype: :class:`..G90Alarm`
+        :return: Parent :class:`.G90Alarm` instance
+        :rtype: :class:`.G90Alarm`
         """
         return self._parent
 

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -157,7 +157,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
      (those having multiple nodes)
     :param proto_idx int: Index of the sensor within list of sensors as
      retrieved from the alarm panel
-    :param kwargs: Pass-through keyword arguments for :class:`.G90Sensor` for 
+    :param kwargs: Pass-through keyword arguments for :class:`.G90Sensor` for
      interpreting protocol fields
     """
     def __init__(self, *args, parent, subindex, proto_idx, **kwargs):
@@ -289,7 +289,8 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     @property
     def parent(self):
         """
-        Returns parent :class:`..G90Alarm` instance the sensor is associated with.
+        Returns parent :class:`..G90Alarm` instance the sensor is associated
+        with.
 
         :return: Parent :class:`..G90Alarm` instance
         :rtype: :class:`..G90Alarm`

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -22,10 +22,14 @@
 Provides interface to sensors of G90 alarm panel.
 """
 
+import logging
 from collections import namedtuple
 from enum import IntEnum, IntFlag
+from ..definitions.sensors import SENSOR_DEFINITIONS
+from ..const import G90Commands
 
-INCOMING_FIELDS = [
+# Common protocol fields across read and write operations
+COMMON_FIELDS = [
     'parent_name',
     'index',
     'room_id',
@@ -37,16 +41,25 @@ INCOMING_FIELDS = [
     'protocol_id',
     'reserved_data',
     'node_count',
+]
+
+# Incoming (read operation) protocol fields
+INCOMING_FIELDS = COMMON_FIELDS + [
     'mask',
-    'private',
-    'parent',
-    'subindex'
+    'private_data',
+]
+
+# Outgoing (write operation) protocol fields
+OUTGOING_FIELDS = COMMON_FIELDS + [
+    'rx',
+    'tx',
+    'private_data',
 ]
 
 
 class G90SensorReservedFlags(IntFlag):
     """
-    tbd
+    Reserved flags of the sensor.
 
     :meta private:
     """
@@ -58,7 +71,7 @@ class G90SensorReservedFlags(IntFlag):
 
 class G90SensorUserFlags(IntFlag):
     """
-    tbd
+    User flags of the sensor.
 
     :meta private:
     """
@@ -75,7 +88,7 @@ class G90SensorUserFlags(IntFlag):
 
 class G90SensorProtocols(IntEnum):
     """
-    tbd
+    Protocol types for the sensors.
 
     :meta private:
     """
@@ -90,7 +103,7 @@ class G90SensorProtocols(IntEnum):
 
 class G90SensorTypes(IntEnum):
     """
-    tbd
+    Sensor types.
 
     :meta private:
     """
@@ -118,6 +131,7 @@ class G90SensorTypes(IntEnum):
     SLIDINGWIN = 131
     AIRCON = 136
     TV = 137
+    NIGHTLIGHT = 138
     SOCKET_2_4G = 140
     SIREN_2_4G = 141
     SWITCH_2_4G = 142
@@ -127,88 +141,296 @@ class G90SensorTypes(IntEnum):
     UNKNOWN = 255
 
 
-class G90Sensor(namedtuple('G90Sensor', INCOMING_FIELDS)):
+_LOGGER = logging.getLogger(__name__)
+
+
+class G90Sensor:  # pylint:disable=too-many-instance-attributes
     """
-    tbd
+    Interacts with sensor on G90 alarm panel.
+
+    :param args: Pass-through positional arguments for :class:`.G90Sensor` for
+     interpreting protocol fields
+    :param parent: Instance of :class:`..G90Alarm` the sensor is associated
+     with
+    :type parent: :class:`..G90Alarm`
+    :param subindex int: Index of the sensor within multi-channel devices
+     (those having multiple nodes)
+    :param proto_idx int: Index of the sensor within list of sensors as
+     retrieved from the alarm panel
+    :param kwargs: Pass-through keyword arguments for :class:`.G90Sensor` for 
+     interpreting protocol fields
     """
-    _occupancy = False
-    _state_callback = None
+    def __init__(self, *args, parent, subindex, proto_idx, **kwargs):
+        self._protocol_incoming_data_kls = (
+            namedtuple('G90Sensor', INCOMING_FIELDS)
+        )
+        self._protocol_outgoing_data_kls = (
+            namedtuple('G90Sensor', OUTGOING_FIELDS)
+        )
+        self._protocol_data = self._protocol_incoming_data_kls(*args, **kwargs)
+        self._parent = parent
+        self._subindex = subindex
+        self._occupancy = False
+        self._state_callback = None
+        self._proto_idx = proto_idx
+
+        self._definition = None
+        # Get sensor definition corresponds to the sensor type/subtype if any
+        for s_def in SENSOR_DEFINITIONS:
+            if (
+                s_def.type == self._protocol_data.type_id
+                and s_def.subtype == self._protocol_data.subtype  # noqa:W503
+            ):
+                self._definition = s_def
+                break
 
     @property
     def name(self):
         """
-        tbd
-        """
-        if self.node_count == 1:
-            return self.parent_name
-        return f'{self.parent_name}#{self.subindex + 1}'
+        Returns sensor name, accounting for multi-channel entities (single
+        protocol entiry results in multiple `G90Sensor` instances).
 
-    @property
-    def enabled(self):
+        :return: Sensor name
+        :rtype: str
         """
-        tbd
-        """
-        return self.user_flag & G90SensorUserFlags.ENABLED
+        if self._protocol_data.node_count == 1:
+            return self._protocol_data.parent_name
+        return f'{self._protocol_data.parent_name}#{self._subindex + 1}'
 
     @property
     def state_callback(self):
         """
-        tbd
+        Returns state callback the sensor might have set.
+
+        :return: Sensor state callback
+        :rtype: object
         """
         return self._state_callback
 
     @state_callback.setter
     def state_callback(self, value):
         """
-        tbd
+        Sets callback for the state changes of the sensor.
+
+        :param value object: Sensor state callback
         """
         self._state_callback = value
 
     @property
     def occupancy(self):
         """
-        tbd
+        Occupancy (occupied/not occupied, or triggered/not triggered)
+        for the sensor.
+
+        :return: Sensor occupancy
+        :rtype: bool
         """
         return self._occupancy
 
     @occupancy.setter
     def occupancy(self, value):
         """
-        tbd
+        Sets occupancy state for the sensor.
+
+        :param value bool: Sensor occupancy
         """
         self._occupancy = value
 
     @property
     def protocol(self):
         """
-        tbd
+        Returns protocol type of the sensor.
+
+        :return: Protocol type
+        :rtype: int
         """
-        return G90SensorProtocols(self.protocol_id)
+        return G90SensorProtocols(self._protocol_data.protocol_id)
 
     @property
     def type(self):
         """
-        tbd
+        Returns type of the sensor.
+
+        :return: Sensor type
+        :rtype: int
         """
-        return G90SensorTypes(self.type_id)
+        return G90SensorTypes(self._protocol_data.type_id)
 
     @property
     def reserved(self):
         """
-        tbd
+        Returns reserved flags (read/write mode) for the sensor.
+
+        :return: Reserved flags
+        :rtype: int
         """
-        return G90SensorReservedFlags(self.reserved_data)
+        return G90SensorReservedFlags(self._protocol_data.reserved_data)
 
     @property
     def user_flag(self):
         """
-        tbd
+        Returns user flags for the sensor (disabled/enabled, arming type etc).
+
+        :return: User flags
+        :rtype: int
         """
-        return G90SensorUserFlags(self.user_flag_data)
+        return G90SensorUserFlags(self._protocol_data.user_flag_data)
+
+    @property
+    def node_count(self):
+        """
+        Returns number of nodes (channels) for the sensor.
+
+        :return: Number of nodes
+        :rtype: int
+        """
+        return self._protocol_data.node_count
+
+    @property
+    def parent(self):
+        """
+        Returns parent :class:`..G90Alarm` instance the sensor is associated with.
+
+        :return: Parent :class:`..G90Alarm` instance
+        :rtype: :class:`..G90Alarm`
+        """
+        return self._parent
+
+    @property
+    def index(self):
+        """
+        Returns index (internal position) of the sensor in the G90 alarm panel.
+
+        :return: Internal sensor position
+        :rtype: int
+        """
+        return self._protocol_data.index
+
+    @property
+    def subindex(self):
+        """
+        Returns index of the sensor within multi-node device.
+
+        :return: Index of sensor in multi-node device.
+        :rtype: int
+        """
+        return self._subindex
+
+    @property
+    def supports_enable_disable(self):
+        """
+        Indicates if disabling/enabling the sensor is supported.
+
+        :return: Support for enabling/disabling the sensor
+        :rtype: bool
+        """
+        return self._definition is not None
+
+    @property
+    def enabled(self):
+        """
+        Indicates if the sensor is enabled.
+
+        :return: If sensor is enabled
+        :rtype: bool
+        """
+        return self.user_flag & G90SensorUserFlags.ENABLED
+
+    async def set_enabled(self, value):
+        """
+        Sets disabled/enabled state of the sensor.
+
+        :param value bool: Whether to enable or disable the sensor
+        """
+        if not self.supports_enable_disable:
+            _LOGGER.warning(
+                'Manipulating with enable/disable for sensor index=%s'
+                ' is unsupported - no sensor definition for'
+                ' type=%s, subtype=%s',
+                self.index,
+                self._protocol_data.type_id,
+                self._protocol_data.subtype
+            )
+
+            return
+
+        # Refresh actual sensor data from the alarm panel before modifying it.
+        # This implies the sensor is at the same position within sensor list
+        # (`_proto_index`) as it has been read initially from the alarm panel
+        # when instantiated.
+        _LOGGER.debug(
+            'Refreshing sensor at index=%s, position in protocol list=%s',
+            self.index, self._proto_idx
+        )
+        sensors = self.parent.paginated_result(
+            G90Commands.GETSENSORLIST,
+            start=self._proto_idx, end=self._proto_idx
+        )
+
+        # Compare actual sensor data from what the sensor has been instantiated
+        # from, and abort the operation if out-of-band changes are detected.
+        _sensor_pos, sensor_data = [x async for x in sensors][0]
+        if self._protocol_incoming_data_kls(
+            *sensor_data
+        ) != self._protocol_data:
+            _LOGGER.error(
+                "Sensor index=%s '%s' has been changed externally,"
+                " refusing to alter its enable/disable state",
+                self.index,
+                self.name
+            )
+            return
+
+        # Modify the value of the user flag setting enabled/disabled one
+        # appropriately.
+        user_flag = self.user_flag
+        if value:
+            user_flag |= G90SensorUserFlags.ENABLED
+        else:
+            user_flag &= ~G90SensorUserFlags.ENABLED
+
+        # Re-instantiate the protocol data with modified user flags
+        _data = self._protocol_data._asdict()
+        _data['user_flag_data'] = user_flag
+        self._protocol_data = self._protocol_incoming_data_kls(**_data)
+
+        _LOGGER.debug(
+            'Sensor index=%s: %s enabled flag, resulting user_flag %s',
+            self._protocol_data.index,
+            'Setting' if value else 'Clearing',
+            self.user_flag
+        )
+
+        # Generate protocol data from write operation, deriving values either
+        # from fields read from the sensor, or from the sensor definition - not
+        # all fields are present during read, only in definition.
+        outgoing_data = self._protocol_outgoing_data_kls(
+            parent_name=self._protocol_data.parent_name,
+            index=self._protocol_data.index,
+            room_id=self._protocol_data.room_id,
+            type_id=self._protocol_data.type_id,
+            subtype=self._protocol_data.subtype,
+            timeout=self._protocol_data.timeout,
+            user_flag_data=self._protocol_data.user_flag_data,
+            baudrate=self._protocol_data.baudrate,
+            protocol_id=self._protocol_data.protocol_id,
+            reserved_data=self._definition.reserved_data,
+            node_count=self._protocol_data.node_count,
+            rx=self._definition.rx,
+            tx=self._definition.tx,
+            private_data=self._definition.private_data,
+        )
+        # Modify the sensor
+        await self._parent.command(
+            G90Commands.SETSINGLESENSOR, list(outgoing_data)
+        )
 
     def __repr__(self):
         """
-        tbd
+        Returns string representation of the sensor.
+
+        :return: String representation
+        :rtype: str
         """
         return super().__repr__() + f'(name={str(self.name)}' \
             f' type={str(self.type)}' \

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -148,17 +148,17 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     """
     Interacts with sensor on G90 alarm panel.
 
-    :param args: Pass-through positional arguments for
-     :class:`.G90SensorIncomingData` for interpreting protocol fields
+    :param args: Pass-through positional arguments for for interpreting
+     protocol fields
     :param parent: Instance of :class:`.G90Alarm` the sensor is associated
      with
     :type parent: :class:`.G90Alarm`
-    :param subindex int: Index of the sensor within multi-channel devices
+    :param int subindex: Index of the sensor within multi-channel devices
      (those having multiple nodes)
-    :param proto_idx int: Index of the sensor within list of sensors as
+    :param int proto_idx: Index of the sensor within list of sensors as
      retrieved from the alarm panel
-    :param kwargs: Pass-through keyword arguments for
-     :class:`.G90SensorIncomingData` for interpreting protocol fields
+    :param kwargs: Pass-through keyword arguments for for interpreting protocol
+     fields
     """
     def __init__(self, *args, parent, subindex, proto_idx, **kwargs):
         self._protocol_incoming_data_kls = (
@@ -212,7 +212,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         """
         Sets callback for the state changes of the sensor.
 
-        :param value object: Sensor state callback
+        :param object value: Sensor state callback
         """
         self._state_callback = value
 
@@ -232,7 +232,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         """
         Sets occupancy state for the sensor.
 
-        :param value bool: Sensor occupancy
+        :param bool value: Sensor occupancy
         """
         self._occupancy = value
 
@@ -341,7 +341,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         """
         Sets disabled/enabled state of the sensor.
 
-        :param value bool: Whether to enable or disable the sensor
+        :param bool value: Whether to enable or disable the sensor
         """
         if not self.supports_enable_disable:
             _LOGGER.warning(

--- a/src/pyg90alarm/paginated_result.py
+++ b/src/pyg90alarm/paginated_result.py
@@ -24,6 +24,7 @@ to work with results of paginated commands.
 """
 
 import logging
+from collections import namedtuple
 from .paginated_cmd import G90PaginatedCommand
 from .const import (
     CMD_PAGE_SIZE,
@@ -32,9 +33,17 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+class G90PaginatedResponse(
+    namedtuple('G90PaginatedResponse', ['proto_idx', 'data'])
+):
+    """
+    Response yielded from the `G90PaginatedResult.process()` method
+    """
+
+
 class G90PaginatedResult:
     """
-    tbd
+    Processes paginated response from G90 corresponding panel commands.
     """
     # pylint: disable=too-few-public-methods
     def __init__(self, host, port, code, start=1, end=None, **kwargs):
@@ -48,7 +57,8 @@ class G90PaginatedResult:
 
     async def process(self):
         """
-        tbd
+        Process paginated response yielding `G90PaginatedResponse` instance for
+        each element.
         """
         page = CMD_PAGE_SIZE
         start = self._start
@@ -85,8 +95,9 @@ class G90PaginatedResult:
                 self._end = cmd.total
 
             # Produce the resulting records for the consumer
-            for res in cmd.result:
-                yield res
+            for proto_idx, data in enumerate(cmd.result):
+                # Protocol uses one-based indexes
+                yield G90PaginatedResponse(proto_idx + 1, data)
 
             # Count the number of processed records
             count += cmd.count

--- a/src/pyg90alarm/paginated_result.py
+++ b/src/pyg90alarm/paginated_result.py
@@ -37,7 +37,7 @@ class G90PaginatedResponse(
     namedtuple('G90PaginatedResponse', ['proto_idx', 'data'])
 ):
     """
-    Response yielded from the `G90PaginatedResult.process()` method
+    Response yielded from the :meth:`.G90PaginatedResult.process` method
     """
 
 
@@ -57,8 +57,8 @@ class G90PaginatedResult:
 
     async def process(self):
         """
-        Process paginated response yielding `G90PaginatedResponse` instance for
-        each element.
+        Process paginated response yielding :class:`.G90PaginatedResponse`
+        instance for each element.
         """
         page = CMD_PAGE_SIZE
         start = self._start

--- a/src/pyg90alarm/paginated_result.py
+++ b/src/pyg90alarm/paginated_result.py
@@ -95,9 +95,12 @@ class G90PaginatedResult:
                 self._end = cmd.total
 
             # Produce the resulting records for the consumer
-            for proto_idx, data in enumerate(cmd.result):
-                # Protocol uses one-based indexes
-                yield G90PaginatedResponse(proto_idx + 1, data)
+            for idx, data in enumerate(cmd.result):
+                # Protocol uses one-based indexes, `start` implies that so no
+                # further additions to resulting value is needed.
+                # Note the index provided here is running one across multiple
+                # pages hence use of `start` variable
+                yield G90PaginatedResponse(start + idx, data)
 
             # Count the number of processed records
             count += cmd.count

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -448,3 +448,104 @@ class TestG90Alarm(G90Fixture):
                 b"ISTART[116,116,[116,[1]]]IEND\0",
             ]
         )
+
+    async def test_sensor_disable(self):
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (
+                b'ISTART[102,'
+                b'[[2,1,2],'
+                b'["Night Light1",11,0,138,0,0,33,0,0,17,1,0,""],'
+                b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (
+                b'ISTART[102,'
+                b'[[2,2,1],'
+                b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+
+        sensors = await g90.sensors
+        self.assertEqual(sensors[1].enabled, True)
+        await sensors[1].set_enabled(False)
+        self.assertEqual(sensors[1].enabled, False)
+        self.assert_callargs_on_sent_data([
+            b'ISTART[102,102,[102,[1,10]]]IEND\0',
+            b'ISTART[102,102,[102,[2,2]]]IEND\0',
+            b'ISTART[103,103,[103,'
+            b'["Night Light2",10,0,138,0,0,32,0,0,17,1,0,2,"060A0600"]'
+            b']]IEND\0',
+        ])
+
+    async def test_sensor_disable_externally_modified(self):
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (
+                b'ISTART[102,'
+                b'[[2,1,2],'
+                b'["Night Light1",11,0,138,0,0,33,0,0,17,1,0,""],'
+                b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (
+                b'ISTART[102,'
+                b'[[2,2,1],'
+                b'["Night Light2",10,0,138,0,0,1,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+
+        sensors = await g90.sensors
+        self.assertEqual(sensors[1].enabled, True)
+        await sensors[1].set_enabled(False)
+        self.assertEqual(sensors[1].enabled, True)
+        self.assert_callargs_on_sent_data([
+            b'ISTART[102,102,[102,[1,10]]]IEND\0',
+            b'ISTART[102,102,[102,[2,2]]]IEND\0',
+        ])
+
+    async def test_sensor_unsupported_disable(self):
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (
+                b'ISTART[102,'
+                b'[[1,1,1],["Water",10,0,7,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+
+        sensors = await g90.sensors
+        self.assertEqual(sensors[0].enabled, True)
+        await sensors[0].set_enabled(False)
+        self.assert_callargs_on_sent_data([
+            b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        ])
+
+    async def test_device_unsupported_disable(self):
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (
+                b'ISTART[138,'
+                b'[[1,1,1],["Water",10,0,7,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (b"ISTARTIEND\0", ("mocked", 12345)),
+        ]
+
+        devices = await g90.devices
+        self.assertEqual(devices[0].enabled, True)
+        await devices[0].set_enabled(False)
+        self.assert_callargs_on_sent_data([
+            b'ISTART[138,138,[138,[1,10]]]IEND\0',
+        ])


### PR DESCRIPTION
* Added support for enabling/disabling sensors - each `G90Sensor` now has `set_enabled()` method that ensures no out-of-band modifications to sensor have been done and then writes the sensor data back to the panel with user flag having `enabled` bit set correspondingly. Note that outgoing protocol data for the sensor is different from one during the read operation - the former contains fields not present during read, thus separate sensor definitions (list of `G90SensorDefinition`) have been introduced holding RX/TX/match mode and R/W mode values for particular sensor types.