### PR TITLE
`G90Alarm` methods for async properties. Removed Python 3.6 from testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.6
-            toxenv: py
-          - os: ubuntu-latest
             python: 3.7
             toxenv: py
           - os: ubuntu-latest
@@ -27,6 +24,9 @@ jobs:
             toxenv: py
           - os: ubuntu-latest
             python: 3.9
+            toxenv: py
+          - os: ubuntu-latest
+            python: 3.10
             toxenv: py
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,27 +17,27 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.7
+            python: '3.7'
             toxenv: py
           - os: ubuntu-latest
-            python: 3.8
+            python: '3.8'
             toxenv: py
           - os: ubuntu-latest
-            python: 3.9
+            python: '3.9'
             toxenv: py
           - os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Disable shallow clone for Sonar scanner, as it needs access to the
           # history
           fetch-depth: 0
       - name: Set Python up
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
@@ -73,11 +73,11 @@ jobs:
     needs: [tests]
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # `setuptools_scm` needs tags
       - name: Set Python up
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install the PEP517 package builder

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         id: package-version
         run: |
           package_version=`python3 setup.py --version`
-          echo "::set-output name=VALUE::$package_version"
+          echo "VALUE=$package_version" >> $GITHUB_OUTPUT
       - name: SonarCloud scanning
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -179,6 +179,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
     @property
     async def sensors(self):
         """
+        Property over new :meth:`.get_sensors` method, retained for
+        compatibility.
+        """
+        return await self.get_sensors()
+
+    async def get_sensors(self):
+        """
         Provides list of sensors configured in the device. Please note the list
         is cached upon first call, so you need to re-instantiate the class to
         reflect any updates there.
@@ -203,6 +210,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
 
     @property
     async def devices(self):
+        """
+        Property over new :meth:`.get_devices` method, retained for
+        compatibility.
+        """
+        return await self.get_devices()
+
+    async def get_devices(self):
         """
         Provides list of devices (switches) configured in the device. Please
         note the list is cached upon first call, so you need to re-instantiate
@@ -239,6 +253,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
     @property
     async def host_info(self):
         """
+        Property over new :meth:`.get_host_info` method, retained for
+        compatibility.
+        """
+        return await self.get_host_info()
+
+    async def get_host_info(self):
+        """
         Provides the device information (for example hardware versions, signal
         levels etc.).
 
@@ -250,6 +271,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
 
     @property
     async def host_status(self):
+        """
+        Property over new :meth:`.get_host_status` method, retained for
+        compatibility.
+        """
+        return await self.get_host_status()
+
+    async def get_host_status(self):
         """
         Provides the device status (for example, armed or disarmed, configured
         phone number, product name etc.).
@@ -263,6 +291,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
 
     @property
     async def alert_config(self):
+        """
+        Property over new :meth:`.get_alert_config` method, retained for
+        compatibility.
+        """
+        return await self.get_alert_config()
+
+    async def get_alert_config(self):
         """
         Retrieves the alert configuration flags from the device. Please note
         the configuration is cached upon first call, so you need to
@@ -308,6 +343,13 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
 
     @property
     async def user_data_crc(self):
+        """
+        Property over new :meth:`.get_user_data_crc` method, retained for
+        compatibility.
+        """
+        return await self.get_user_data_crc()
+
+    async def get_user_data_crc(self):
         """
         Retieves checksums (CRC) for different on-device databases (history,
         sensors etc.). Might be used to detect if there is a change in a
@@ -453,7 +495,7 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
     @door_open_close_callback.setter
     def door_open_close_callback(self, value):
         """
-        tbd
+        Sets callback for door open/close events.
         """
         self._door_open_close_cb = value
 

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -37,7 +37,7 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[100,[3,"PHONE","PRODUCT","206","206"]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.host_status
+        res = await g90.get_host_status()
         self.assert_callargs_on_sent_data([b'ISTART[100,100,""]IEND\0'])
         self.assertIsInstance(res, G90HostStatus)
         self.assertEqual(res.host_status, 3)
@@ -51,7 +51,7 @@ class TestG90Alarm(G90Fixture):
             b'"1.2","1.1","206","206",3,3,0,2,"4242",50,100]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.host_info
+        res = await g90.get_host_info()
         self.assert_callargs_on_sent_data([b'ISTART[206,206,""]IEND\0'])
         self.assertIsInstance(res, G90HostInfo)
         self.assertEqual(res.host_guid, 'DUMMYGUID')
@@ -64,7 +64,7 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[160,["1","0xab","3","4","5","6"]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.user_data_crc
+        res = await g90.get_user_data_crc()
         self.assert_callargs_on_sent_data([b'ISTART[160,160,""]IEND\0'])
         self.assertIsInstance(res, G90UserDataCRC)
         self.assertEqual(res.sensor_list, '1')
@@ -80,7 +80,7 @@ class TestG90Alarm(G90Fixture):
                b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        devices = await g90.devices
+        devices = await g90.get_devices()
         self.assert_callargs_on_sent_data([
             b'ISTART[138,138,[138,[1,10]]]IEND\0',
         ])
@@ -95,7 +95,7 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[138,' \
                b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,2,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
-        devices = await g90.devices
+        devices = await g90.get_devices()
         self.assert_callargs_on_sent_data([
             b'ISTART[138,138,[138,[1,10]]]IEND\0',
         ])
@@ -114,7 +114,7 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[138,' \
                b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
-        devices = await g90.devices
+        devices = await g90.get_devices()
 
         data = b'ISTARTIEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
@@ -132,7 +132,7 @@ class TestG90Alarm(G90Fixture):
                b'[[1,1,1],["Remote",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
         ])
@@ -152,7 +152,7 @@ class TestG90Alarm(G90Fixture):
 
         self.socket_mock.recvfrom.side_effect = data
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
         ])
@@ -190,7 +190,7 @@ class TestG90Alarm(G90Fixture):
 
         self.socket_mock.recvfrom.side_effect = data
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
             b'ISTART[102,102,[102,[11,11]]]IEND\0',
@@ -214,7 +214,7 @@ class TestG90Alarm(G90Fixture):
                 ]
         self.socket_mock.recvfrom.side_effect = data
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         future = self.loop.create_future()
         sensor = [x for x in sensors if x.index == 10 and x.name == 'Remote']
         sensor[0].state_callback = lambda *args: future.set_result(True)
@@ -288,7 +288,7 @@ class TestG90Alarm(G90Fixture):
         asynctest.set_read_ready(socket_ntfy_mock, self.loop)
         await asyncio.wait([future], timeout=0.1)
         # Corresponding sensor should turn to occupied (=door opened)
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assertEqual(sensors[0].occupancy, True)
 
         # Signal the second alert is ready, the future has to be re-created as
@@ -297,7 +297,7 @@ class TestG90Alarm(G90Fixture):
         asynctest.set_read_ready(socket_ntfy_mock, self.loop)
         await asyncio.wait([future], timeout=0.1)
         # The sensor should become inactive (=door closed)
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assertEqual(sensors[0].occupancy, False)
 
         g90.close_device_notifications()
@@ -352,7 +352,7 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[117,[1]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.alert_config
+        res = await g90.get_alert_config()
         self.assert_callargs_on_sent_data([b'ISTART[117,117,""]IEND\0'])
         self.assertIsInstance(res, G90AlertConfigFlags)
 
@@ -366,7 +366,7 @@ class TestG90Alarm(G90Fixture):
         ]
 
         await g90.set_alert_config(
-            await g90.alert_config
+            await g90.get_alert_config()
             | G90AlertConfigFlags.AC_POWER_FAILURE  # noqa:W503
             | G90AlertConfigFlags.HOST_LOW_VOLTAGE  # noqa:W503
         )
@@ -379,7 +379,7 @@ class TestG90Alarm(G90Fixture):
         )
         # Validate we retrieve same alert configuration just has been set
         self.assertEqual(
-            await g90.alert_config,
+            await g90.get_alert_config(),
             G90AlertConfigFlags.AC_POWER_FAILURE
             | G90AlertConfigFlags.HOST_LOW_VOLTAGE  # noqa:W503
         )
@@ -398,7 +398,7 @@ class TestG90Alarm(G90Fixture):
         asynctest.set_read_ready(socket_ntfy_mock, self.loop)
         self.socket_mock.recvfrom.side_effect = [
             # First command to get alert configuration is from
-            # `G90Alarm.alert_config` property
+            # `G90Alarm.get_alert_config()` property
             (b"ISTART[117,[1]]IEND\0", ("mocked", 12345)),
             # Second command for same is invoked by `G90Alarm.set_alert_config`
             # that checks if alert config has been modified externally
@@ -470,7 +470,7 @@ class TestG90Alarm(G90Fixture):
             (b"ISTARTIEND\0", ("mocked", 12345)),
         ]
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assertEqual(sensors[1].enabled, True)
         await sensors[1].set_enabled(False)
         self.assertEqual(sensors[1].enabled, False)
@@ -503,7 +503,7 @@ class TestG90Alarm(G90Fixture):
             (b"ISTARTIEND\0", ("mocked", 12345)),
         ]
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assertEqual(sensors[1].enabled, True)
         await sensors[1].set_enabled(False)
         self.assertEqual(sensors[1].enabled, True)
@@ -524,7 +524,7 @@ class TestG90Alarm(G90Fixture):
             (b"ISTARTIEND\0", ("mocked", 12345)),
         ]
 
-        sensors = await g90.sensors
+        sensors = await g90.get_sensors()
         self.assertEqual(sensors[0].enabled, True)
         await sensors[0].set_enabled(False)
         self.assert_callargs_on_sent_data([
@@ -543,7 +543,7 @@ class TestG90Alarm(G90Fixture):
             (b"ISTARTIEND\0", ("mocked", 12345)),
         ]
 
-        devices = await g90.devices
+        devices = await g90.get_devices()
         self.assertEqual(devices[0].enabled, True)
         await devices[0].set_enabled(False)
         self.assert_callargs_on_sent_data([

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -64,15 +64,21 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[160,["1","0xab","3","4","5","6"]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.get_user_data_crc()
-        self.assert_callargs_on_sent_data([b'ISTART[160,160,""]IEND\0'])
-        self.assertIsInstance(res, G90UserDataCRC)
-        self.assertEqual(res.sensor_list, '1')
-        self.assertEqual(res.device_list, '0xab')
-        self.assertEqual(res.history_list, '3')
-        self.assertEqual(res.scene_list, '4')
-        self.assertEqual(res.ifttt_list, '5')
-        self.assertEqual(res.fingerprint_list, '6')
+        crc = await g90.get_user_data_crc()
+        prop_crc = await g90.user_data_crc
+        assert crc == prop_crc
+
+        self.assert_callargs_on_sent_data([
+            b'ISTART[160,160,""]IEND\0',
+            b'ISTART[160,160,""]IEND\0',
+        ])
+        self.assertIsInstance(crc, G90UserDataCRC)
+        self.assertEqual(crc.sensor_list, '1')
+        self.assertEqual(crc.device_list, '0xab')
+        self.assertEqual(crc.history_list, '3')
+        self.assertEqual(crc.scene_list, '4')
+        self.assertEqual(crc.ifttt_list, '5')
+        self.assertEqual(crc.fingerprint_list, '6')
 
     async def test_devices(self):
         g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
@@ -81,6 +87,8 @@ class TestG90Alarm(G90Fixture):
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
         devices = await g90.get_devices()
+        prop_devices = await g90.devices
+        assert devices == prop_devices
         self.assert_callargs_on_sent_data([
             b'ISTART[138,138,[138,[1,10]]]IEND\0',
         ])
@@ -96,6 +104,8 @@ class TestG90Alarm(G90Fixture):
                b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,2,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
         devices = await g90.get_devices()
+        prop_devices = await g90.devices
+        assert devices == prop_devices
         self.assert_callargs_on_sent_data([
             b'ISTART[138,138,[138,[1,10]]]IEND\0',
         ])
@@ -115,6 +125,8 @@ class TestG90Alarm(G90Fixture):
                b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
         devices = await g90.get_devices()
+        prop_devices = await g90.devices
+        assert devices == prop_devices
 
         data = b'ISTARTIEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
@@ -133,6 +145,8 @@ class TestG90Alarm(G90Fixture):
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
         ])
@@ -153,6 +167,8 @@ class TestG90Alarm(G90Fixture):
         self.socket_mock.recvfrom.side_effect = data
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
         ])
@@ -191,6 +207,8 @@ class TestG90Alarm(G90Fixture):
         self.socket_mock.recvfrom.side_effect = data
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
             b'ISTART[102,102,[102,[11,11]]]IEND\0',
@@ -215,6 +233,8 @@ class TestG90Alarm(G90Fixture):
         self.socket_mock.recvfrom.side_effect = data
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         future = self.loop.create_future()
         sensor = [x for x in sensors if x.index == 10 and x.name == 'Remote']
         sensor[0].state_callback = lambda *args: future.set_result(True)
@@ -289,6 +309,8 @@ class TestG90Alarm(G90Fixture):
         await asyncio.wait([future], timeout=0.1)
         # Corresponding sensor should turn to occupied (=door opened)
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assertEqual(sensors[0].occupancy, True)
 
         # Signal the second alert is ready, the future has to be re-created as
@@ -298,6 +320,8 @@ class TestG90Alarm(G90Fixture):
         await asyncio.wait([future], timeout=0.1)
         # The sensor should become inactive (=door closed)
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assertEqual(sensors[0].occupancy, False)
 
         g90.close_device_notifications()
@@ -352,9 +376,11 @@ class TestG90Alarm(G90Fixture):
         data = b'ISTART[117,[1]]IEND\0'
         self.socket_mock.recvfrom.return_value = (data, ('mocked', 12345))
 
-        res = await g90.get_alert_config()
+        config = await g90.get_alert_config()
+        prop_config = await g90.alert_config
+        assert config == prop_config
         self.assert_callargs_on_sent_data([b'ISTART[117,117,""]IEND\0'])
-        self.assertIsInstance(res, G90AlertConfigFlags)
+        self.assertIsInstance(config, G90AlertConfigFlags)
 
     async def test_set_alert_config(self):
         """ Tests for setting alert configuration to the the device """
@@ -471,6 +497,8 @@ class TestG90Alarm(G90Fixture):
         ]
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assertEqual(sensors[1].enabled, True)
         await sensors[1].set_enabled(False)
         self.assertEqual(sensors[1].enabled, False)
@@ -504,6 +532,8 @@ class TestG90Alarm(G90Fixture):
         ]
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assertEqual(sensors[1].enabled, True)
         await sensors[1].set_enabled(False)
         self.assertEqual(sensors[1].enabled, True)
@@ -525,6 +555,8 @@ class TestG90Alarm(G90Fixture):
         ]
 
         sensors = await g90.get_sensors()
+        prop_sensors = await g90.sensors
+        assert sensors == prop_sensors
         self.assertEqual(sensors[0].enabled, True)
         await sensors[0].set_enabled(False)
         self.assert_callargs_on_sent_data([
@@ -544,6 +576,8 @@ class TestG90Alarm(G90Fixture):
         ]
 
         devices = await g90.get_devices()
+        prop_devices = await g90.devices
+        assert devices == prop_devices
         self.assertEqual(devices[0].enabled, True)
         await devices[0].set_enabled(False)
         self.assert_callargs_on_sent_data([

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,15 +22,11 @@ class TestG90Notifications(G90Fixture):
         asynctest.set_read_ready(self.socket_mock, self.loop)
         with self.assertLogs(level='ERROR') as cm:
             await asyncio.wait([future], timeout=0.1)
-            self.assertIn(
-                cm.output[0], [
-                    'ERROR:pyg90alarm.device_notifications:Device message'
-                    " '[170]' is malformed: <lambda>() missing 1 required"
-                    " positional argument: 'data'",
-                    'ERROR:pyg90alarm.device_notifications:Device message'
-                    " '[170]' is malformed: __new__() missing 1 required"
-                    " positional argument: 'data'",
-                ]
+            self.assertRegex(
+                cm.output[0],
+                'ERROR:pyg90alarm.device_notifications:Device message'
+                r" '\[170\]' is malformed: .+ missing 1 required"
+                " positional argument: 'data'",
             )
         notifications.close()
 
@@ -84,14 +80,12 @@ class TestG90Notifications(G90Fixture):
         asynctest.set_read_ready(self.socket_mock, self.loop)
         with self.assertLogs(level='ERROR') as cm:
             await asyncio.wait([future], timeout=0.1)
-            self.assertIn(cm.output[0], [
+            self.assertRegex(
+                cm.output[0],
                 'ERROR:pyg90alarm.device_notifications:'
                 'Bad notification received from mocked:12345:'
-                " <lambda>() missing 1 required positional argument: 'data'",
-                'ERROR:pyg90alarm.device_notifications:'
-                'Bad notification received from mocked:12345:'
-                " __new__() missing 1 required positional argument: 'data'",
-            ])
+                " .+ missing 1 required positional argument: 'data'",
+            )
         notifications.close()
 
     async def test_wrong_device_alert_format(self):
@@ -105,18 +99,14 @@ class TestG90Notifications(G90Fixture):
         asynctest.set_read_ready(self.socket_mock, self.loop)
         with self.assertLogs(level='ERROR') as cm:
             await asyncio.wait([future], timeout=0.1)
-            self.assertIn(cm.output[0], [
+            self.assertRegex(
+                cm.output[0],
                 'ERROR:pyg90alarm.device_notifications:'
                 'Bad alert received from mocked:12345:'
-                " <lambda>() missing 9 required positional arguments: 'type',"
+                " .+ missing 9 required positional arguments: 'type',"
                 " 'event_id', 'source', 'state', 'zone_name', 'device_id',"
                 " 'unix_time', 'resv4', and 'other'",
-                'ERROR:pyg90alarm.device_notifications:'
-                'Bad alert received from mocked:12345:'
-                " __new__() missing 9 required positional arguments: 'type',"
-                " 'event_id', 'source', 'state', 'zone_name', 'device_id',"
-                " 'unix_time', 'resv4', and 'other'",
-            ])
+            )
         notifications.close()
 
     async def test_unknown_device_notification(self):

--- a/tests/test_paginated_commands.py
+++ b/tests/test_paginated_commands.py
@@ -19,13 +19,12 @@ class TestG90PaginatedCommand(G90Fixture):
 
         with self.assertRaises(G90Error, ) as cm:
             await g90.process()
-        self.assertIn(cm.exception.args[0],
-                      ['Wrong pagination data [] -'
-                       ' <lambda>() missing 3 required positional arguments:'
-                       " 'total', 'start', and 'count'",
-                       'Wrong pagination data [] -'
-                       ' __new__() missing 3 required positional arguments:'
-                       " 'total', 'start', and 'count'"])
+        self.assertRegex(
+            cm.exception.args[0],
+            r'Wrong pagination data \[\] -'
+            ' .+ missing 3 required positional arguments:'
+            " 'total', 'start', and 'count'",
+        )
 
         self.assert_callargs_on_sent_data([
             b'ISTART[102,102,[102,[1,1]]]IEND\0'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,38,39,310}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
* `G90Alarm` has got methods corresponding to async properties, those add complication to be mocked at the caller side. Both async methods and corresponding properties will continue to exist for at least some time, to retain compatibility - callers can use either of those whatever has better convenience
* Removed Python 3.6 from testing, added 3.10 instead
* Github workflow: checkout/setup-python actions updated to `v3`