### PR TITLE
Alarm callback support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,17 @@ setup(
         'Topic :: System :: Hardware',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
     ],
 
     keywords='g90, alarm, protocol',
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
     install_requires=[],
 
     extras_require={

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.python.version=3.6, 3.7, 3.8, 3.9
+sonar.python.version=3.7, 3.8, 3.9, 3.10
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPaths=pylint.txt
 sonar.python.flake8.reportPaths=flake8.txt

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -107,6 +107,7 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
         self._sensor_cb = None
         self._armdisarm_cb = None
         self._door_open_close_cb = None
+        self._alarm_cb = None
         self._reset_occupancy_interval = reset_occupancy_interval
         self._alert_config = None
         self._sms_alert_when_armed = False
@@ -535,6 +536,20 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
     def armdisarm_callback(self, value):
         self._armdisarm_cb = value
 
+    @property
+    def alarm_callback(self):
+        """
+        Get or set device alarm callback, the callback is invoked when
+        device alarm triggers.
+
+        :type: .. py:function:: ()(sensor_idx: int, sensor_name: str)
+        """
+        return self._alarm_cb
+
+    @alarm_callback.setter
+    def alarm_callback(self, value):
+        self._alarm_cb = value
+
     async def listen_device_notifications(self, sock=None):
         """
         Starts internal listener for device notifications/alerts.
@@ -546,6 +561,7 @@ class G90Alarm:  # pylint: disable=too-many-public-methods
             sensor_cb=self._internal_sensor_cb,
             door_open_close_cb=self._internal_door_open_close_cb,
             armdisarm_cb=self._internal_armdisarm_cb,
+            alarm_cb=self._alarm_cb,
             sock=sock)
         await self._notifications.listen()
 

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -363,10 +363,11 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             'Refreshing sensor at index=%s, position in protocol list=%s',
             self.index, self._proto_idx
         )
-        sensors = self.parent.paginated_result(
+        sensors_result = self.parent.paginated_result(
             G90Commands.GETSENSORLIST,
             start=self._proto_idx, end=self._proto_idx
         )
+        sensors = [x async for x in sensors_result]
 
         # Abort if sensor is not found
         if not sensors:
@@ -379,7 +380,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
 
         # Compare actual sensor data from what the sensor has been instantiated
         # from, and abort the operation if out-of-band changes are detected.
-        _sensor_pos, sensor_data = [x async for x in sensors][0]
+        _sensor_pos, sensor_data = sensors[0]
         if self._protocol_incoming_data_kls(
             *sensor_data
         ) != self._protocol_data:

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -368,6 +368,15 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             start=self._proto_idx, end=self._proto_idx
         )
 
+        # Abort if sensor is not found
+        if not sensors:
+            _LOGGER.error(
+                'Sensor index=%s not found when attempting to set its'
+                ' enable/disable state',
+                self.index,
+            )
+            return
+
         # Compare actual sensor data from what the sensor has been instantiated
         # from, and abort the operation if out-of-band changes are detected.
         _sensor_pos, sensor_data = [x async for x in sensors][0]

--- a/src/pyg90alarm/paginated_result.py
+++ b/src/pyg90alarm/paginated_result.py
@@ -94,6 +94,11 @@ class G90PaginatedResult:
                                 ' latter', self._end, cmd.total)
                 self._end = cmd.total
 
+            _LOGGER.debug('Retrieved %i records in the iteration,'
+                          ' %i available in total, target end'
+                          ' record number is %i',
+                          cmd.count, cmd.total, self._end)
+
             # Produce the resulting records for the consumer
             for idx, data in enumerate(cmd.result):
                 # Protocol uses one-based indexes, `start` implies that so no
@@ -107,11 +112,9 @@ class G90PaginatedResult:
 
             # End the loop if we processed same number of sensors as in the
             # pagination header (or attempted to process more than that by
-            # an error)
-            _LOGGER.debug('Retrieved %i records in the iteration,'
-                          ' %i available in total, target end'
-                          ' record number is %i',
-                          cmd.count, cmd.total, self._end)
+            # an error), or no records have been received
+            if not cmd.count:
+                break
             if cmd.start + cmd.count - 1 >= self._end:
                 break
             # Move to the next page for another iteration

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -563,6 +563,34 @@ class TestG90Alarm(G90Fixture):
             b'ISTART[102,102,[102,[1,10]]]IEND\0',
         ])
 
+    async def test_sensor_disable_sensor_not_found_on_refresh(self):
+        import logging
+        logging.basicConfig(level='DEBUG')
+        g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
+        self.socket_mock.recvfrom.side_effect = [
+            (
+                b'ISTART[102,'
+                b'[[2,1,2],'
+                b'["Night Light1",11,0,138,0,0,33,0,0,17,1,0,""],'
+                b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+                b']]IEND\0',
+                ('mocked', 12345)
+            ),
+            (
+                b'ISTART[102,[[2,2,0]]]IEND\0',
+                ('mocked', 12345)
+            ),
+        ]
+
+        sensors = await g90.get_sensors()
+        self.assertEqual(sensors[1].enabled, True)
+        await sensors[1].set_enabled(False)
+        self.assertEqual(sensors[1].enabled, True)
+        self.assert_callargs_on_sent_data([
+            b'ISTART[102,102,[102,[1,10]]]IEND\0',
+            b'ISTART[102,102,[102,[2,2]]]IEND\0',
+        ])
+
     async def test_device_unsupported_disable(self):
         g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
         self.socket_mock.recvfrom.side_effect = [

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -564,8 +564,6 @@ class TestG90Alarm(G90Fixture):
         ])
 
     async def test_sensor_disable_sensor_not_found_on_refresh(self):
-        import logging
-        logging.basicConfig(level='DEBUG')
         g90 = G90Alarm(host='mocked', port=12345, sock=self.socket_mock)
         self.socket_mock.recvfrom.side_effect = [
             (

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
     pylint --output-format=parseable --output=pylint.txt src/pyg90alarm
 	# Ensure only traces for in-repository module is processed, not for one
 	# installed by `tox` (see above for more details)
-    coverage run --source=src/pyg90alarm --parallel-mode -m unittest -v tests
+    coverage run --source=src/pyg90alarm --parallel-mode -m unittest -v tests []
 commands_post =
 	# Show the `pylint` report to the standard output, to ease fixing the issues reported
 	cat pylint.txt


### PR DESCRIPTION
* Added support for alarm_callback via `G90Alarm.alarm_callback` property - invoked when the panel triggers alarm, the arguments to the callback are sensor index and sensor name, those led to the trigger
* Added check for no sensor found when refreshing the sensor state before enabling/disabling it
* `G90PaginatedResult`: Fixed processing of empty paginated response,  i.e. no records received - the `process()` method now exits properly  no attempting to switch to a next page incorrectly