### PR TITLE
Support for extra data to sensors, delivered as part of alarm callback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Disable shallow clone for Sonar scanner, as it needs access to the
           # history
           fetch-depth: 0
       - name: Set Python up
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install testing tools
@@ -73,11 +73,11 @@ jobs:
     needs: [tests]
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # `setuptools_scm` needs tags
       - name: Set Python up
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Install the PEP517 package builder

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           # Disable shallow clone for Sonar scanner, as it needs access to the
           # history
@@ -73,7 +73,7 @@ jobs:
     needs: [tests]
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # `setuptools_scm` needs tags
       - name: Set Python up

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -173,6 +173,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         self._occupancy = False
         self._state_callback = None
         self._proto_idx = proto_idx
+        self._extra_data = None
 
         self._definition = None
         # Get sensor definition corresponds to the sensor type/subtype if any
@@ -436,6 +437,18 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             G90Commands.SETSINGLESENSOR, list(outgoing_data)
         )
 
+    @property
+    def extra_data(self):
+        """
+        Sets extra data for the sensor, that can be used to store
+        caller-specific information and will be carried by the sensor instance.
+        """
+        return self._extra_data
+
+    @extra_data.setter
+    def extra_data(self, val):
+        self._extra_data = val
+
     def __repr__(self):
         """
         Returns string representation of the sensor.
@@ -443,9 +456,10 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         :return: String representation
         :rtype: str
         """
-        return super().__repr__() + f'(name={str(self.name)}' \
+        return super().__repr__() + f"(name='{str(self.name)}'" \
             f' type={str(self.type)}' \
             f' protocol={str(self.protocol)}' \
             f' occupancy={self.occupancy}' \
             f' user flag={str(self.user_flag)}' \
-            f' reserved={str(self.reserved)})'
+            f' reserved={str(self.reserved)}' \
+            f" extra_data={str(self.extra_data)})"


### PR DESCRIPTION
## Changes
* Added `G90Sensor.extra_data` property that allows the caller to set any extra data to the sensor, which will be carried on by the `G90Sensor` instance
* Alarm callback if set via `G90Alarm.alarm_callback` is now called with three args when firing - sensor index, sensor name and extra data (see above). This allows the caller to retrieve sensor specific custom data within alarm callback, e.g. a handled to a caller-specific object, additional data to handle alarm properly etc.

## Additionally
* Github Actions: updated to most recent version of `actions/setup-python` to avoid warnings re: using `set-output`