### PR TITLE
Low battery callback. Network code optimization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
           - os: ubuntu-latest
             python: '3.11'
             toxenv: py
+          - os: ubuntu-latest
+            python: '3.12'
+            toxenv: py
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the code

--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -76,6 +76,8 @@ class G90BaseCommand:
                                     separators=(',', ':'))
         self._resp = G90Header()
 
+    # Implementation of datagram protocol,
+    # https://docs.python.org/3/library/asyncio-protocol.html#datagram-protocols
     def connection_made(self, transport):
         """
         tbd

--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -44,62 +44,6 @@ class G90Header(NamedTuple):
     data: Optional[str] = None
 
 
-class G90DeviceProtocol:
-    """
-    tbd
-
-    :meta private:
-    """
-    def __init__(self):
-        """
-        tbd
-        """
-        self._data = None
-
-    @property
-    def future_data(self):
-        """
-        tbd
-        """
-        return self._data
-
-    @future_data.setter
-    def future_data(self, value):
-        """
-        tbd
-        """
-        self._data = value
-
-    def connection_made(self, transport):
-        """
-        tbd
-        """
-
-    def connection_lost(self, exc):
-        """
-        tbd
-        """
-
-    def datagram_received(self, data, addr):
-        """
-        tbd
-        """
-        if asyncio.isfuture(self._data):
-            if self._data.done():
-                _LOGGER.warning('Excessive packet received'
-                                ' from %s:%s: %s',
-                                addr[0], addr[1], data)
-                return
-            self._data.set_result((*addr, data))
-
-    def error_received(self, exc):
-        """
-        tbd
-        """
-        if asyncio.isfuture(self._data) and not self._data.done():
-            self._data.set_exception(exc)
-
-
 class G90BaseCommand:
     """
     tbd
@@ -123,6 +67,7 @@ class G90BaseCommand:
         self._retries = retries
         self._data = '""'
         self._result = None
+        self._connection_result = None
         if data:
             self._data = json.dumps([code, data],
                                     # No newlines to be inserted
@@ -131,11 +76,37 @@ class G90BaseCommand:
                                     separators=(',', ':'))
         self._resp = G90Header()
 
-    def _proto_factory(self):
+    def connection_made(self, transport):
         """
         tbd
         """
-        return G90DeviceProtocol()
+
+    def connection_lost(self, exc):
+        """
+        tbd
+        """
+
+    def datagram_received(self, data, addr):
+        """
+        tbd
+        """
+        if asyncio.isfuture(self._connection_result):
+            if self._connection_result.done():
+                _LOGGER.warning('Excessive packet received'
+                                ' from %s:%s: %s',
+                                addr[0], addr[1], data)
+                return
+            self._connection_result.set_result((*addr, data))
+
+    def error_received(self, exc):
+        """
+        tbd
+        """
+        if (
+            asyncio.isfuture(self._connection_result) and not
+            self._connection_result.done()
+        ):
+            self._connection_result.set_exception(exc)
 
     async def _create_connection(self):
         """
@@ -153,7 +124,7 @@ class G90BaseCommand:
             extra_kwargs['local_addr'] = ('0.0.0.0', self._local_port)
 
         transport, protocol = await loop.create_datagram_endpoint(
-            self._proto_factory,
+            lambda: self,
             remote_addr=(self.host, self.port),
             **extra_kwargs,
             allow_broadcast=True)
@@ -241,7 +212,7 @@ class G90BaseCommand:
         tbd
         """
 
-        transport, protocol = await self._create_connection()
+        transport, _ = await self._create_connection()
         attempts = self._retries
         while True:
             attempts = attempts - 1
@@ -249,24 +220,24 @@ class G90BaseCommand:
                 loop = asyncio.get_running_loop()
             except AttributeError:
                 loop = asyncio.get_event_loop()
-            protocol.future_data = loop.create_future()
+            self._connection_result = loop.create_future()
             async with self._sk_lock:
                 _LOGGER.debug('(code %s) Sending request to %s:%s',
                               self._code, self.host, self.port)
                 transport.sendto(self.to_wire())
-                done, _ = await asyncio.wait([protocol.future_data],
+                done, _ = await asyncio.wait([self._connection_result],
                                              timeout=self._timeout)
-            if protocol.future_data in done:
+            if self._connection_result in done:
                 break
             # Cancel the future to signal protocol handler it is no longer
             # valid, the future will be re-created on next retry
-            protocol.future_data.cancel()
+            self._connection_result.cancel()
             if not attempts:
                 transport.close()
                 raise G90TimeoutError()
             _LOGGER.debug('Timed out, retrying')
         transport.close()
-        (host, port, data) = protocol.future_data.result()
+        (host, port, data) = self._connection_result.result()
         _LOGGER.debug('Received response from %s:%s', host, port)
         if self.host != '255.255.255.255':
             if self.host != host or host == '255.255.255.255':

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -189,6 +189,16 @@ class G90AlertSources(IntEnum):
     DOORBELL = 12
 
 
+class G90AlertStates(IntEnum):
+    """
+    Defines possible states of the alert sent by the panel.
+    """
+    DOOR_CLOSE = 0
+    DOOR_OPEN = 1
+    TAMPER = 3
+    LOW_BATTERY = 4
+
+
 class G90AlertStateChangeTypes(IntEnum):
     """
     Defines types of alert for device state changes.

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -43,7 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 class G90Message(namedtuple('G90Message',
                             ['code', 'data'])):
     """
-    tbd
+    Represents the message received from the device.
 
     :meta private:
     """
@@ -52,7 +52,7 @@ class G90Message(namedtuple('G90Message',
 class G90Notification(namedtuple('G90Notification',
                                  ['kind', 'data'])):
     """
-    tbd
+    Represents the notification received from the device.
 
     :meta private:
     """
@@ -61,7 +61,7 @@ class G90Notification(namedtuple('G90Notification',
 class G90ZoneInfo(namedtuple('G90ZoneInfo',
                              ['idx', 'name'])):
     """
-    tbd
+    Represents zone details received from the device.
 
     :meta private:
     """
@@ -70,7 +70,7 @@ class G90ZoneInfo(namedtuple('G90ZoneInfo',
 class G90ArmDisarmInfo(namedtuple('G90ArmDisarmInfo',
                                   ['state'])):
     """
-    tbd
+    Represents the arm/disarm state received from the device.
 
     :meta private:
     """
@@ -81,7 +81,7 @@ class G90DeviceAlert(namedtuple('G90DeviceAlert',
                                  'zone_name', 'device_id', 'unix_time',
                                  'resv4', 'other'])):
     """
-    tbd
+    Represents alert received from the device.
 
     :meta private:
     """
@@ -96,16 +96,6 @@ class G90DeviceNotifications:
         self._notification_transport = None
         self._notifications_host = host
         self._notifications_port = port
-
-    def connection_made(self, transport):
-        """
-        tbd
-        """
-
-    def connection_lost(self, exc):
-        """
-        tbd
-        """
 
     def _handle_notification(self, addr, notification):
         # Sensor activity notification
@@ -193,9 +183,21 @@ class G90DeviceNotifications:
                         ' type %s, data %s',
                         addr[0], addr[1], alert.type, alert)
 
+    # Implementation of datagram protocol,
+    # https://docs.python.org/3/library/asyncio-protocol.html#datagram-protocols
+    def connection_made(self, transport):
+        """
+        Invoked when connection from the device is made.
+        """
+
+    def connection_lost(self, exc):
+        """
+        Same but when the connection is lost.
+        """
+
     def datagram_received(self, data, addr):  # pylint:disable=R0911
         """
-        tbd
+        Invoked from datagram is received from the device.
         """
         s_data = data.decode('utf-8')
         if not s_data.endswith('\0'):
@@ -243,32 +245,32 @@ class G90DeviceNotifications:
 
     async def on_armdisarm(self, state):
         """
-        tbd
+        Invoked when device is armed or disarmed.
         """
 
     async def on_sensor_activity(self, idx, name):
         """
-        tbd
+        Invoked on sensor activity.
         """
 
     async def on_door_open_close(self, event_id, zone_name, is_open):
         """
-        tbd
+        Invoked when door sensor reports it opened or closed.
         """
 
     async def on_low_battery(self, event_id, zone_name):
         """
-        tbd
+        Invoked when a sensor reports it is low on battery.
         """
 
     async def on_alarm(self, event_id, zone_name):
         """
-        tbd
+        Invoked when device triggers the alarm.
         """
 
     async def listen(self):
         """
-        tbd
+        Listens for notifications/alers from the device.
         """
         try:
             loop = asyncio.get_running_loop()
@@ -287,7 +289,7 @@ class G90DeviceNotifications:
 
     def close(self):
         """
-        tbd
+        Closes the listener.
         """
         if self._notification_transport:
             self._notification_transport.close()

--- a/src/pyg90alarm/discovery.py
+++ b/src/pyg90alarm/discovery.py
@@ -32,54 +32,6 @@ from .const import G90Commands
 _LOGGER = logging.getLogger(__name__)
 
 
-class G90DiscoveryProtocol:
-    """
-    tbd
-
-    :meta private:
-    """
-    def __init__(self, parent):
-        """
-        tbd
-        """
-        self._parent = parent
-
-    def connection_made(self, transport):
-        """
-        tbd
-        """
-
-    def connection_lost(self, exc):
-        """
-        tbd
-        """
-
-    def datagram_received(self, data, addr):
-        """
-        tbd
-        """
-        try:
-            ret = self._parent.from_wire(data)
-            host_info = G90HostInfo(*ret)
-            _LOGGER.debug('Received from %s:%s: %s', addr[0], addr[1], ret)
-            res = {
-                'guid': host_info.host_guid,
-                'host': addr[0],
-                'port': addr[1]
-            }
-            res.update(host_info._asdict())
-            _LOGGER.debug('Discovered device: %s', res)
-            self._parent.add_device(res)
-
-        except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.warning('Got exception, ignoring: %s', exc)
-
-    def error_received(self, exc):
-        """
-        tbd
-        """
-
-
 class G90Discovery(G90BaseCommand):
     """
     tbd
@@ -93,6 +45,26 @@ class G90Discovery(G90BaseCommand):
         super().__init__(code=G90Commands.GETHOSTINFO, timeout=timeout,
                          **kwargs)
         self._discovered_devices = []
+
+    def datagram_received(self, data, addr):
+        """
+        tbd
+        """
+        try:
+            ret = self.from_wire(data)
+            host_info = G90HostInfo(*ret)
+            _LOGGER.debug('Received from %s:%s: %s', addr[0], addr[1], ret)
+            res = {
+                'guid': host_info.host_guid,
+                'host': addr[0],
+                'port': addr[1]
+            }
+            res.update(host_info._asdict())
+            _LOGGER.debug('Discovered device: %s', res)
+            self.add_device(res)
+
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.warning('Got exception, ignoring: %s', exc)
 
     async def process(self):
         """
@@ -118,9 +90,3 @@ class G90Discovery(G90BaseCommand):
         tbd
         """
         self._discovered_devices.append(value)
-
-    def _proto_factory(self):
-        """
-        tbd
-        """
-        return G90DiscoveryProtocol(self)

--- a/src/pyg90alarm/discovery.py
+++ b/src/pyg90alarm/discovery.py
@@ -46,6 +46,8 @@ class G90Discovery(G90BaseCommand):
                          **kwargs)
         self._discovered_devices = []
 
+    # Implementation of datagram protocol,
+    # https://docs.python.org/3/library/asyncio-protocol.html#datagram-protocols
     def datagram_received(self, data, addr):
         """
         tbd

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -172,6 +172,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         self._subindex = subindex
         self._occupancy = False
         self._state_callback = None
+        self._low_battery_callback = None
         self._proto_idx = proto_idx
         self._extra_data = None
 
@@ -216,6 +217,25 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         :param object value: Sensor state callback
         """
         self._state_callback = value
+
+    @property
+    def low_battery_callback(self):
+        """
+        Returns callback the sensor might have set for low battery condition.
+
+        :return: Sensor's low battery callback
+        :rtype: object
+        """
+        return self._low_battery_callback
+
+    @low_battery_callback.setter
+    def low_battery_callback(self, value):
+        """
+        Sets callback for the low battery condition reported by the sensor.
+
+        :param object value: Sensor's low battery callback
+        """
+        self._low_battery_callback = value
 
     @property
     def occupancy(self):

--- a/src/pyg90alarm/targeted_discovery.py
+++ b/src/pyg90alarm/targeted_discovery.py
@@ -68,6 +68,8 @@ class G90TargetedDiscovery(G90Discovery):
         super().__init__(**kwargs)
         self._device_id = device_id
 
+    # Implementation of datagram protocol,
+    # https://docs.python.org/3/library/asyncio-protocol.html#datagram-protocols
     def datagram_received(self, data, addr):
         """
         tbd

--- a/src/pyg90alarm/targeted_discovery.py
+++ b/src/pyg90alarm/targeted_discovery.py
@@ -55,28 +55,18 @@ class G90TargetedDiscoveryInfo(namedtuple('G90TargetedDiscoveryInfo',
     """
 
 
-class G90TargetedDiscoveryProtocol:
+class G90TargetedDiscovery(G90Discovery):
     """
     tbd
-
-    :meta private:
     """
-    def __init__(self, device_id, parent):
+
+    # pylint: disable=too-few-public-methods
+    def __init__(self, device_id, **kwargs):
         """
         tbd
         """
-        self._parent = parent
+        super().__init__(**kwargs)
         self._device_id = device_id
-
-    def connection_made(self, transport):
-        """
-        tbd
-        """
-
-    def connection_lost(self, exc):
-        """
-        tbd
-        """
 
     def datagram_received(self, data, addr):
         """
@@ -95,39 +85,12 @@ class G90TargetedDiscoveryProtocol:
                    'port': addr[1]}
             res.update(host_info._asdict())
             _LOGGER.debug('Discovered device: %s', res)
-            self._parent.add_device(res)
+            self.add_device(res)
         except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.warning('Got exception, ignoring: %s', exc)
-
-    def error_received(self, exc):
-        """
-        tbd
-        """
-
-
-class G90TargetedDiscovery(G90Discovery):
-    """
-    tbd
-    """
-
-    # pylint: disable=too-few-public-methods
-    def __init__(self, device_id, **kwargs):
-        """
-        tbd
-        """
-
-        super().__init__(**kwargs)
-        self._device_id = device_id
 
     def to_wire(self):
         """
         tbd
         """
         return bytes(f'IWTAC_PROBE_DEVICE,{self._device_id}\0', 'ascii')
-
-    def _proto_factory(self):
-        """
-        tbd
-        """
-        return G90TargetedDiscoveryProtocol(self._device_id,
-                                            self)

--- a/tests/test_base_commands.py
+++ b/tests/test_base_commands.py
@@ -7,7 +7,6 @@ sys.path.extend(['src', '../src'])
 
 from pyg90alarm.base_cmd import (  # noqa:E402
     G90BaseCommand,
-    G90DeviceProtocol,
 )
 from pyg90alarm.exceptions import (G90Error, G90TimeoutError)  # noqa:E402
 
@@ -33,11 +32,11 @@ async def test_network_unreachable():
     b'ISTARTIEND\0',
 ])
 async def test_wrong_host(mock_device, monkeypatch):
-    orig = G90DeviceProtocol.datagram_received
+    orig = G90BaseCommand.datagram_received
     # Alter receving method of the device protocol as if it gets datagaram from
     # `another_host`
     monkeypatch.setattr(
-        G90DeviceProtocol, 'datagram_received',
+        G90BaseCommand, 'datagram_received',
         lambda self, data, addr: orig(self, data, ('another_host', addr[1]))
     )
     g90 = G90BaseCommand(
@@ -57,11 +56,11 @@ async def test_wrong_host(mock_device, monkeypatch):
     b'ISTARTIEND\0',
 ])
 async def test_wrong_port(mock_device, monkeypatch):
-    orig = G90DeviceProtocol.datagram_received
+    orig = G90BaseCommand.datagram_received
     # Alter receving method of the device protocol as if it gets datagaram from
     # proper host but different port `54321`
     monkeypatch.setattr(
-        G90DeviceProtocol, 'datagram_received',
+        G90BaseCommand, 'datagram_received',
         lambda self, data, addr: orig(self, data, (addr[0], 54321))
     )
     g90 = G90BaseCommand(

--- a/tox.ini
+++ b/tox.ini
@@ -15,11 +15,18 @@ isolated_build = true
 [testenv]
 deps =
     check-manifest == 0.49
-    flake8 == 7.1.1
-    pytest == 8.3.2
-    pytest-asyncio == 0.23.8
-    pytest-cov == 5.0.0
-    pylint == 3.2.6
+    flake8 == 7.1.1;python_version>"3.7"
+    pytest == 8.3.2;python_version>"3.7"
+    pytest-asyncio == 0.23.8;python_version>"3.7"
+    pytest-cov == 5.0.0;python_version>"3.7"
+    pylint == 3.2.6;python_version>"3.7"
+    # Specific versions for Python 3.7
+    flake8 == 5.0.4;python_version=="3.7"
+    pytest == 7.4.4;python_version=="3.7"
+    pytest-cov == 4.1.0;python_version=="3.7"
+    pylint == 2.17.7;python_version=="3.7"
+    pytest-asyncio == 0.21.2;python_version=="3.7"
+
 setenv =
 	# Ensure the module under test will be found under `src/` directory, in
 	# case of any test command below will attempt importing it. In particular,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{37,38,39,310,311,312}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and
@@ -14,12 +14,12 @@ isolated_build = true
 
 [testenv]
 deps =
-    check-manifest == 0.48
-    flake8 == 4.0.1
-    pytest == 7.2.0
-    pytest-asyncio == 0.20.3
-    pytest-cov == 4.0.0
-    pylint == 2.15.9
+    check-manifest == 0.49
+    flake8 == 7.1.1
+    pytest == 8.3.2
+    pytest-asyncio == 0.23.8
+    pytest-cov == 5.0.0
+    pylint == 3.2.6
 setenv =
 	# Ensure the module under test will be found under `src/` directory, in
 	# case of any test command below will attempt importing it. In particular,
@@ -32,7 +32,6 @@ allowlist_externals =
 	cat
 commands =
     check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties'
-    python setup.py check -m -s
     flake8 --tee --output-file=flake8.txt .
     pylint --output-format=parseable --output=pylint.txt src/pyg90alarm
 	# Ensure only traces for in-repository module is processed, not for one


### PR DESCRIPTION
* Simplified the code around network interactions, there are no longer      separate classes implementing [datagram protocol](https://docs.python.org/3/library/asyncio-protocol.html#datagram-protocols)      - `G90BaseCommand`, `G90DeviceNotifications`, `G90Discovery`,      `G90TargetedDiscovery` classes now implement the protocol      themselves

* `G90Alarm` class now inherits from `G90DeviceNotifications` one, to avoid having separate set of callbacks between those two - now      `G90DeviceNotifications` just implements empty callback methods, and      `G90Alarm` overrides them with required logic. The change comes along      with renames of such callback methods in `G90Alarm` class - those      `_internal_*_cb` been renamed to ones `G90DeviceNotifications`      implements correspondingly

* Added `low_battery_callback` support on `G90Alarm` class level      (centralized callback invoked with sensor ID/name) and per-sensor      `low_battery_callback` one, which is invoked when the sensor having it      set experiences the condition

* `tox`: Updated dependencies and Python 3.12 environment added