### PR TITLE
Device alerts simulation from recorded history

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,13 @@ set the IP address allocation up.
    status will not be reflected and those will always be reported as inactive,
    since there is no way to read their state in a polled manner.
 
+   To work that limitation around the package now supports simulating device
+   notifications from periodically polling the history it records - the
+   simulation works only for the alerts, not notifications (e.g. notifications
+   include low battery events and alike). This also requires the particular
+   alert to be enabled in the mobile application, otherwise it won't be
+   recorded in the history.
+
 Quick start
 ===========
 

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -688,8 +688,8 @@ class G90Alarm(G90DeviceNotifications):
         notifications will not be processed thus resulting in possible
         duplicated if those could be received from the network.
 
-        :param int interval: Interval between polling for newer history
-          entities
+        :param int interval: Interval (in seconds) between polling for newer
+          history entities
         :param int history_depth: Amount of history entries to fetch during
           each polling cycle
         """

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -48,7 +48,7 @@ G90HostInfo(host_guid='<...>',
             wifi_signal_level=100)
 
 """
-
+import asyncio
 import logging
 from .const import (
     G90Commands, REMOTE_PORT,
@@ -113,6 +113,8 @@ class G90Alarm(G90DeviceNotifications):
         self._reset_occupancy_interval = reset_occupancy_interval
         self._alert_config = None
         self._sms_alert_when_armed = False
+        self._alert_simulation_task = None
+        self._alert_simulation_start_listener_back = False
 
     async def command(self, code, data=None):
         """
@@ -406,8 +408,13 @@ class G90Alarm(G90DeviceNotifications):
         """
         res = self.paginated_result(G90Commands.GETHISTORY,
                                     start, count)
-        history = [G90History(*x.data) async for x in res]
-        return history
+
+        # Sort the history entries from older to newer - device typically does
+        # that, but apparently that is not guaranteed
+        return sorted(
+            [G90History(*x.data) async for x in res],
+            key=lambda x: x.datetime, reverse=True
+        )
 
     async def on_sensor_activity(self, idx, name, occupancy=True):
         """
@@ -669,3 +676,108 @@ class G90Alarm(G90DeviceNotifications):
     @sms_alert_when_armed.setter
     def sms_alert_when_armed(self, value):
         self._sms_alert_when_armed = value
+
+    async def start_simulating_alerts_from_history(
+        self, interval=5, history_depth=5
+    ):
+        """
+        Starts the separate task to simulate device alerts from history
+        entries.
+
+        The listener for device notifications will be stopped, so device
+        notifications will not be processed thus resulting in possible
+        duplicated if those could be received from the network.
+
+        :param int interval: Interval between polling for newer history
+          entities
+        :param int history_depth: Amount of history entries to fetch during
+          each polling cycle
+        """
+        # Remember if device notifications listener has been started already
+        self._alert_simulation_start_listener_back = self.listener_started
+        # And then stop it
+        self.close()
+
+        # Start the task
+        self._alert_simulation_task = asyncio.create_task(
+            self._simulate_alerts_from_history(interval, history_depth)
+        )
+
+    async def stop_simulating_alerts_from_history(self):
+        """
+        Stops the task simulating device alerts from history entries.
+
+        The listener for device notifications will be started back, if it was
+        running when simulation has been started.
+        """
+        # Stop the task simulating the device alerts from history if it was
+        # running
+        if self._alert_simulation_task:
+            self._alert_simulation_task.cancel()
+            self._alert_simulation_task = None
+
+        # Start device notifications listener back if it was running when
+        # simulated alerts have been enabled
+        if self._alert_simulation_start_listener_back:
+            await self.listen()
+
+    async def _simulate_alerts_from_history(self, interval, history_depth):
+        """
+        Periodically fetches history entries from the device and simulates
+        device alerts off of those.
+
+        Only the history entries occur after the process is started are
+        handled, to avoid triggering callbacks retrospectively.
+
+        See :method:`start_simulating_alerts_from_history` for the parameters.
+        """
+        last_history_ts = None
+
+        _LOGGER.debug(
+            'Simulating device alerts from history:'
+            ' interval %s, history depth %s',
+            interval, history_depth
+        )
+        while True:
+            # Retrieve the history entries of the specified amount - full
+            # history retrieval might be an unnecessary long operation
+            history = await self.history(count=history_depth)
+
+            # Initial iteration where no timestamp of most recent history entry
+            # is recorded - do that and skip to next iteration, since it isn't
+            # yet known what entries would be considered as new ones
+            if not last_history_ts:
+                # First entry in the list is assumed to be the most recent one
+                last_history_ts = history[0].datetime
+                _LOGGER.debug(
+                    'Initial time stamp of last history entry: %s',
+                    last_history_ts
+                )
+                continue
+
+            # Process history entries from older to newer to preserve the order
+            # of happenings
+            for item in reversed(history):
+                # Process only the entries newer than one been recorded as most
+                # recent one
+                if item.datetime > last_history_ts:
+                    _LOGGER.debug(
+                        'Found newer history entry: %s, simulating alert',
+                        repr(item)
+                    )
+                    # Send the history entry down the device notification code
+                    # as alert, as if it came from the device and its
+                    # notifications port
+                    self._handle_alert(
+                        (self._host, self._notifications_port),
+                        item.as_device_alert()
+                    )
+
+                    # Record the entry as most recent one
+                    last_history_ts = item.datetime
+                    _LOGGER.debug(
+                        'Time stamp of last history entry: %s', last_history_ts
+                    )
+
+            # Sleep to next iteration
+            await asyncio.sleep(interval)

--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -185,6 +185,7 @@ class G90AlertSources(IntEnum):
     """
     Defines possible sources of the alert sent by the panel.
     """
+    DEVICE = 0
     SENSOR = 1
     DOORBELL = 12
 
@@ -211,3 +212,21 @@ class G90AlertStateChangeTypes(IntEnum):
     LOW_BATTERY = 6
     WIFI_CONNECTED = 7
     WIFI_DISCONNECTED = 8
+
+
+class G90HistoryStates(IntEnum):
+    """
+    Defines possible states for history entities.
+    """
+    DOOR_CLOSE = 1
+    DOOR_OPEN = 2
+    TAMPER = 3
+    ALARM = 4
+    AC_POWER_FAILURE = 5
+    AC_POWER_RECOVER = 6
+    DISARM = 7
+    ARM_AWAY = 8
+    ARM_HOME = 9
+    LOW_BATTERY = 10
+    WIFI_CONNECTED = 11
+    WIFI_DISCONNECTED = 12

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -287,9 +287,18 @@ class G90DeviceNotifications:
                 self._notifications_host, self._notifications_port
             ))
 
+    @property
+    def listener_started(self):
+        '''
+        tbd
+        '''
+        return self._notification_transport is not None
+
     def close(self):
         """
         Closes the listener.
         """
         if self._notification_transport:
+            _LOGGER.debug('No longer listenting for device notifications')
             self._notification_transport.close()
+            self._notification_transport = None

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -289,9 +289,11 @@ class G90DeviceNotifications:
 
     @property
     def listener_started(self):
-        '''
-        tbd
-        '''
+        """
+        Indicates if the listener of the device notifications has been started.
+
+        :rtype: bool
+        """
         return self._notification_transport is not None
 
     def close(self):
@@ -299,6 +301,6 @@ class G90DeviceNotifications:
         Closes the listener.
         """
         if self._notification_transport:
-            _LOGGER.debug('No longer listenting for device notifications')
+            _LOGGER.debug('No longer listening for device notifications')
             self._notification_transport.close()
             self._notification_transport = None

--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -22,7 +22,7 @@
 History protocol entity.
 """
 
-import time
+from datetime import datetime, timezone
 from collections import namedtuple
 from .const import (
     G90AlertTypes,
@@ -89,9 +89,12 @@ class G90History:
     def datetime(self):
         """
         Date/time of the history entry.
-        :rtype: :class:`Datetime`
+
+        :rtype: :class:`datetime.datetime`
         """
-        return time.ctime(self._protocol_data.unix_time)
+        return datetime.fromtimestamp(
+            self._protocol_data.unix_time, tz=timezone.utc
+        )
 
     @property
     def type(self):

--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -24,33 +24,192 @@ History protocol entity.
 
 import time
 from collections import namedtuple
+from .const import (
+    G90AlertTypes,
+    G90AlertSources,
+    G90AlertStates,
+    G90AlertStateChangeTypes,
+    G90HistoryStates,
+)
+from .device_notifications import G90DeviceAlert
+
+
+# The state of the incoming history entries are mixed of `G90AlertStates` and
+# `G90AlertStateChangeTypes`, depending on entry type - the mapping
+# consilidates them into unified `G90HistoryStates`. The latter enum can't be
+# just an union of former two, since those have conflicting values
+states_mapping = {
+    G90AlertStates.DOOR_CLOSE:
+        G90HistoryStates.DOOR_CLOSE,
+    G90AlertStates.DOOR_OPEN:
+        G90HistoryStates.DOOR_OPEN,
+    G90AlertStates.TAMPER:
+        G90HistoryStates.TAMPER,
+    G90AlertStates.LOW_BATTERY:
+        G90HistoryStates.LOW_BATTERY,
+    G90AlertStateChangeTypes.AC_POWER_FAILURE:
+        G90HistoryStates.AC_POWER_FAILURE,
+    G90AlertStateChangeTypes.AC_POWER_RECOVER:
+        G90HistoryStates.AC_POWER_RECOVER,
+    G90AlertStateChangeTypes.DISARM:
+        G90HistoryStates.DISARM,
+    G90AlertStateChangeTypes.ARM_AWAY:
+        G90HistoryStates.ARM_AWAY,
+    G90AlertStateChangeTypes.ARM_HOME:
+        G90HistoryStates.ARM_HOME,
+    G90AlertStateChangeTypes.LOW_BATTERY:
+        G90HistoryStates.LOW_BATTERY,
+    G90AlertStateChangeTypes.WIFI_CONNECTED:
+        G90HistoryStates.WIFI_CONNECTED,
+    G90AlertStateChangeTypes.WIFI_DISCONNECTED:
+        G90HistoryStates.WIFI_DISCONNECTED,
+}
 
 INCOMING_FIELDS = [
-    'log_type',  # (1 or 3 - alarm, 2 or 4 - notification)
-    'param1',    # (type 1: 1 - SOS, 2 - tamper alarm; type 3 - device ID; type
-                 #  2 - 5 stayarm, 3 - disarm, 4 - awayarm )
-    'param2',    # (type 3: device type)
-    'param3',
+    'type',
+    'event_id',
+    'source',
+    'state',
     'sensor_name',
     'unix_time',
-    'rest',
+    'other',
 ]
+# Class representing the data incoming from the device
+ProtocolData = namedtuple('ProtocolData', INCOMING_FIELDS)
 
 
-class G90History(namedtuple('G90History', INCOMING_FIELDS)):
+class G90History:
     """
     tbd
     """
+    def __init__(self, *args, **kwargs):
+        self._protocol_data = ProtocolData(*args, **kwargs)
 
     @property
     def datetime(self):
         """
-        tbd
+        Date/time of the history entry.
+        :rtype: :class:`Datetime`
         """
-        return time.ctime(self.unix_time)
+        return time.ctime(self._protocol_data.unix_time)
+
+    @property
+    def type(self):
+        """
+        Type of the history entry.
+
+        :rtype: :class:`.G90AlertTypes`
+        """
+        return G90AlertTypes(self._protocol_data.type)
+
+    @property
+    def state(self):
+        """
+        State for the history entry.
+
+        :rtype: :class:`.G90HistoryStates`
+        """
+        # Door open/close type, mapped against `G90AlertStates` using `state`
+        # incoming field
+        if self.type == G90AlertTypes.DOOR_OPEN_CLOSE:
+            return G90HistoryStates(
+                states_mapping[G90AlertStates(self._protocol_data.state)]
+            )
+
+        # Device state change, mapped against `G90AlertStateChangeTypes` using
+        # `event_id` incoming field
+        if self.type == G90AlertTypes.STATE_CHANGE:
+            return G90HistoryStates(
+                states_mapping[
+                    G90AlertStateChangeTypes(self._protocol_data.event_id)
+                ]
+            )
+
+        # Alarm gets mapped to its counterpart in `G90HistoryStates`
+        if self.type == G90AlertTypes.ALARM:
+            return G90HistoryStates.ALARM
+
+        # Other types are mapped against `G90AlertStateChangeTypes`
+        return G90HistoryStates(
+            states_mapping[
+                G90AlertStateChangeTypes(self._protocol_data.event_id)
+            ]
+        )
+
+    @property
+    def source(self):
+        """
+        Source of the history entry.
+
+        :rtype: :class:`.G90AlertSources`
+        """
+        # Device state changes or open/close events are mapped against
+        # `G90AlertSources` using `source` incoming field
+        if self.type in [
+            G90AlertTypes.STATE_CHANGE, G90AlertTypes.DOOR_OPEN_CLOSE
+        ]:
+            return G90AlertSources(self._protocol_data.source)
+
+        # Alarm will have `SENSOR` as the source, since that is likely what
+        # triggered it
+        if self.type == G90AlertTypes.ALARM:
+            return G90AlertSources.SENSOR
+
+        # Other sources are assumed to be initiated by device itself
+        return G90AlertSources.DEVICE
+
+    @property
+    def sensor_name(self):
+        """
+        Name of the sensor related to the history entry, might be empty if none
+        associated.
+
+        :rtype: str|None
+        """
+        return self._protocol_data.sensor_name or None
+
+    @property
+    def sensor_idx(self):
+        """
+        ID of the sensor related to the history entry, might be empty if none
+        associated.
+
+        :rtype: str|None
+        """
+        # Sensor ID will only be available if entry source is a sensor
+        if self.source == G90AlertSources.SENSOR:
+            return self._protocol_data.event_id
+
+        return None
+
+    def as_device_alert(self):
+        """
+        Returns the history entry represented as device alert structure,
+        suitable for :method:`G90DeviceNotifications._handle_alert()`.
+
+        :rtype: :class:`.G90DeviceAlert`
+        """
+        return G90DeviceAlert(
+            type=self._protocol_data.type,
+            event_id=self._protocol_data.event_id,
+            source=self._protocol_data.source,
+            state=self._protocol_data.state,
+            zone_name=self._protocol_data.sensor_name,
+            device_id=None,
+            unix_time=self._protocol_data.unix_time,
+            resv4=None,
+            other=self._protocol_data.other
+        )
 
     def __repr__(self):
         """
-        tbd
+        Textural representation of the history entry.
+
+        :rtype: str
         """
-        return super().__repr__() + f'(datetime={str(self.datetime)})'
+        return f'type={repr(self.type)}' \
+            + f' source={repr(self.source)}' \
+            + f' state={repr(self.state)}' \
+            + f' sensor_name={self.sensor_name}' \
+            + f' sensor_idx={self.sensor_idx}' \
+            + f' datetime={repr(self.datetime)}'

--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -188,7 +188,7 @@ class G90History:
     def as_device_alert(self):
         """
         Returns the history entry represented as device alert structure,
-        suitable for :method:`G90DeviceNotifications._handle_alert()`.
+        suitable for :meth:`G90DeviceNotifications._handle_alert`.
 
         :rtype: :class:`.G90DeviceAlert`
         """

--- a/tox.ini
+++ b/tox.ini
@@ -51,3 +51,5 @@ commands_post =
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs
 select = E,W,F
+# Disable line break before operator warning, as it conflicts with W504 one
+extend-ignore = W503


### PR DESCRIPTION
* The package now supports simulating device notifications from periodically polling the history it records - the simulation works only for the alerts, not notifications (e.g. notifications include low battery events and alike). This also requires the particular alert to be enabled in the mobile application, otherwise it won't be recorded in the history. Primary purpose of the functionality is to allow corresponding callbacks to fire even the network setup prevents broadcast notifications from being received
* `G90Alarm.history` now return the entries with unified values for the fields - primarily addressing the `state` one meant for different entities depending on the record type