### PR TITLE
feat: Per-sensor `is_low_battery` and `is_wireless` properties

### DIFF
--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -211,9 +211,4 @@ class G90History:
         """
         Textural representation of the history entry.
         """
-        return f'type={repr(self.type)}' \
-            + f' source={repr(self.source)}' \
-            + f' state={repr(self.state)}' \
-            + f' sensor_name={self.sensor_name}' \
-            + f' sensor_idx={self.sensor_idx}' \
-            + f' datetime={repr(self.datetime)}'
+        return super().__repr__() + f'({repr(self._asdict())})'


### PR DESCRIPTION
* Added `G90Sensor.is_low_battery` property that indicates corresponding condition on the sensor. Its accompanying method, `G90Sensor._set_low_battery()` is private intentionally, since the flag should only set by the package reflecting panel's alerts. The property is reset when the sensor reports any activity, since that implies it has some battery power still
* Manipulating with `G90Sensor.occupancy` property of a sensor a made similar to low battery one above - there is no longer property setter, rather `G90Sensor._set_occupancy()` method. The argumentation is same
  - the occupancy is set following panel's notification/alerts
* Added better debug messages for both private methods above
* Added `is_wireless` property indicating if the sensor is wireless based on its definition
* `G90Sensor.__repr__()` and `G90History.__repr__()` methods now utilize `._asdict()` methods of the corresponding class