### PR TITLE
chore: Development requirements extracted from `tox`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,5 @@ include LICENSE
 include setup.py
 
 recursive-include src py.typed
+
+exclude requirements_dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ local_scheme = "no-local-version"
 log_cli = 1
 log_cli_level = "error"
 asyncio_mode = "auto"
+pythonpath = "src/"
 
 [tool.coverage.run]
 relative_files = true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,7 @@
+check-manifest == 0.49
+flake8 == 7.1.1
+pytest == 8.3.2
+pytest-asyncio == 0.23.8
+pytest-cov == 5.0.0
+pylint == 3.2.6
+mypy[reports] == 1.11.2

--- a/tox.ini
+++ b/tox.ini
@@ -14,22 +14,8 @@ isolated_build = true
 
 [testenv]
 deps =
-    check-manifest == 0.49
-    flake8 == 7.1.1
-    pytest == 8.3.2
-    pytest-asyncio == 0.23.8
-    pytest-cov == 5.0.0
-    pylint == 3.2.6
-    mypy[reports] == 1.11.2
+    -r requirements_dev.txt
 
-setenv =
-	# Ensure the module under test will be found under `src/` directory, in
-	# case of any test command below will attempt importing it. In particular,
-	# it helps `coverage` to recognize test traces from the module under `src/`
-	# directory and report correct (aligned with repository layout) paths, not
-	# from the module installed by `tox` in the virtual environment (the traces
-	# will be referencing `tox` specific paths, not aligned with repository)
-    PYTHONPATH = src
 allowlist_externals =
 	cat
 commands =


### PR DESCRIPTION
* To support development workflows rather than based on `tox`, the development requirements have been extracted to separate file, `requirements_dev.txt`
* Similarly to the above, `src/` directory is added for `pytest` in `pyproject.toml`, so that tests could be run outside of `tox`