### PR TITLE
fix: Proper types for user-visible callbacks in `G90Sensor`

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -100,21 +100,24 @@ if TYPE_CHECKING:
         Callable[[int, str, bool], None],
         Callable[[int, str, bool], Coroutine[None, None, None]]
     ]
-    SensorStateCallback = Union[
-        Callable[[bool], None],
-        Callable[[bool], Coroutine[None, None, None]]
-    ]
     LowBatteryCallback = Union[
         Callable[[int, str], None],
         Callable[[int, str], Coroutine[None, None, None]]
     ]
-    SensorLowBatteryCallback = Union[
-        Callable[[bool], None],
-        Callable[[bool], Coroutine[None, None, None]]
-    ]
     ArmDisarmCallback = Union[
         Callable[[G90ArmDisarmTypes], None],
         Callable[[G90ArmDisarmTypes], Coroutine[None, None, None]]
+    ]
+    # Sensor-related callbacks for `G90Sensor` class - despite that class
+    # stores them, the invication is done by the `G90Alarm` class hence these
+    # are defined here
+    SensorStateCallback = Union[
+        Callable[[bool], None],
+        Callable[[bool], Coroutine[None, None, None]]
+    ]
+    SensorLowBatteryCallback = Union[
+        Callable[[], None],
+        Callable[[], Coroutine[None, None, None]]
     ]
 
 


### PR DESCRIPTION
* `SensorLowBatteryCallback` type has been fixed, indicating no arguments are passed to low battery callback on `G90Sensor` class level