### PR TITLE
fix: Proper handling of UTF-8 encoding errors in device messages

### DIFF
--- a/src/pyg90alarm/base_cmd.py
+++ b/src/pyg90alarm/base_cmd.py
@@ -154,7 +154,12 @@ class G90BaseCommand(DatagramProtocol):
         Parses the response from the alarm panel.
         """
         _LOGGER.debug('To be decoded from wire format %s', data)
-        self._parse(data.decode('utf-8', errors='ignore'))
+        try:
+            self._parse(data.decode('utf-8'))
+        except UnicodeDecodeError as exc:
+            raise G90Error(
+                'Unable to decode response from UTF-8'
+            ) from exc
         return self._resp.data or []
 
     def _parse(self, data: str) -> None:

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -255,7 +255,12 @@ class G90DeviceNotifications(DatagramProtocol):
             )
             return
 
-        s_data = data.decode('utf-8')
+        try:
+            s_data = data.decode('utf-8')
+        except UnicodeDecodeError:
+            _LOGGER.error('Unable to decode device message from UTF-8')
+            return
+
         if not s_data.endswith('\0'):
             _LOGGER.error('Missing end marker in data')
             return

--- a/src/pyg90alarm/targeted_discovery.py
+++ b/src/pyg90alarm/targeted_discovery.py
@@ -103,7 +103,12 @@ class G90TargetedDiscovery(G90BaseCommand):
         """
         try:
             _LOGGER.debug('Received from %s:%s: %s', addr[0], addr[1], data)
-            decoded = data.decode('utf-8', errors='ignore')
+            try:
+                decoded = data.decode('utf-8')
+            except UnicodeDecodeError as exc:
+                raise G90Error(
+                    'Unable to decode discovery response from UTF-8'
+                ) from exc
             if not decoded.endswith('\0'):
                 raise G90Error('Invalid discovery response')
             host_info = G90TargetedDiscoveryInfo(*decoded[:-1].split(','))

--- a/tests/test_base_commands.py
+++ b/tests/test_base_commands.py
@@ -118,6 +118,26 @@ async def test_timeout(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
+    b'\xdeadbeef\0',
+])
+async def test_invalid_utf8_encoding(mock_device: DeviceMock) -> None:
+    """
+    Verifies that invalid UTF-8 encodingof response is handled properly.
+    """
+    g90 = G90BaseCommand(
+        host=mock_device.host, port=mock_device.port,
+        code=G90Commands.GETHOSTINFO
+    )
+
+    with pytest.raises(
+        G90Error,
+        match=re.escape("Unable to decode response from UTF-8")
+    ):
+        await g90.process()
+    assert mock_device.recv_data == [b'ISTART[206,206,""]IEND\0']
+
+
+@pytest.mark.g90device(sent_data=[
     b'ISTART[IEND\0',
 ])
 async def test_wrong_format(mock_device: DeviceMock) -> None:

--- a/tests/test_base_commands.py
+++ b/tests/test_base_commands.py
@@ -122,7 +122,7 @@ async def test_timeout(mock_device: DeviceMock) -> None:
 ])
 async def test_invalid_utf8_encoding(mock_device: DeviceMock) -> None:
     """
-    Verifies that invalid UTF-8 encodingof response is handled properly.
+    Verifies that invalid UTF-8 encoding of response is handled properly.
     """
     g90 = G90BaseCommand(
         host=mock_device.host, port=mock_device.port,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -58,6 +58,31 @@ async def test_targeted_discovery(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
+    b'\xdeadbeef'
+])
+async def test_targeted_discovery_invalid_utf_response(
+    mock_device: DeviceMock, caplog: LogCaptureFixture
+) -> None:
+    """
+    Verifies that invalid UTF-8 data in response to targeted discovery is
+    logged but ignored.
+    """
+    g90 = G90TargetedDiscovery(
+        device_id='DUMMYGUID',
+        host=mock_device.host,
+        port=mock_device.port,
+        local_port=LOCAL_TARGETED_DISCOVERY_PORT,
+        timeout=0.1)
+
+    caplog.set_level('WARNING')
+    await g90.process()
+    assert ''.join(caplog.messages) == (
+        'Got exception, ignoring:'
+        ' Unable to decode discovery response from UTF-8'
+    )
+
+
+@pytest.mark.g90device(sent_data=[
     b'IWTAC_PROBE_DEVICE_ACK_BAD,TSV018-3SIA'
     b',1.2,1.1,206,1.8,3,3,1,0,2,50,100\0',
 ])

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -16,6 +16,29 @@ from .device_mock import DeviceMock
 
 
 @pytest.mark.g90device(notification_data=[
+    b'\xdeadbeef\0',
+])
+async def test_device_notification_invalid_utf_data(
+    mock_device: DeviceMock, caplog: LogCaptureFixture
+) -> None:
+    """
+    Verifies that wrong UTF encoded data in device notification is handled
+    correctly.
+    """
+    notifications = G90DeviceNotifications(
+        local_host=mock_device.notification_host,
+        local_port=mock_device.notification_port
+    )
+    caplog.set_level('ERROR')
+    await notifications.listen()
+    await mock_device.send_next_notification()
+    assert ''.join(caplog.messages) == (
+        "Unable to decode device message from UTF-8"
+    )
+    notifications.close()
+
+
+@pytest.mark.g90device(notification_data=[
     b'[170]\0',
 ])
 async def test_device_notification_missing_header(


### PR DESCRIPTION
* Any device messages (responses to commands, targeted discovery and notification messages) are now properly handled for invalid UTF-8 encoded data