### PR TITLE
fix: Better processing of history entries

### DIFF
--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -166,7 +166,10 @@ class G90NotificationTypes(IntEnum):
     Defines types of notifications sent by the alarm panel.
     """
     ARM_DISARM = 1
+    SENSOR_ADDED = 4
     SENSOR_ACTIVITY = 5
+    DOOR_OPEN_WHEN_ARMING = 6
+    FIRMWARE_UPDATING = 8
 
 
 class G90ArmDisarmTypes(IntEnum):
@@ -195,7 +198,10 @@ class G90AlertSources(IntEnum):
     """
     DEVICE = 0
     SENSOR = 1
+    REMOTE = 10
+    RFID = 11
     DOORBELL = 12
+    FINGERPRINT = 15
 
 
 class G90AlertStates(IntEnum):
@@ -204,6 +210,7 @@ class G90AlertStates(IntEnum):
     """
     DOOR_CLOSE = 0
     DOOR_OPEN = 1
+    SOS = 2
     TAMPER = 3
     LOW_BATTERY = 4
 

--- a/src/pyg90alarm/history.py
+++ b/src/pyg90alarm/history.py
@@ -136,7 +136,15 @@ class G90History:
                         G90AlertStates(self._protocol_data.state)
                     ]
                 )
+        except ValueError:
+            _LOGGER.warning(
+                "Can't interpret '%s' as alert state (decoded protocol"
+                " data '%s', raw data '%s')",
+                self._protocol_data.state, self._protocol_data, self._raw_data
+            )
+            return None
 
+        try:
             # Other types are mapped against `G90AlertStateChangeTypes`
             return G90HistoryStates(
                 states_mapping_state_changes[
@@ -145,9 +153,10 @@ class G90History:
             )
         except ValueError:
             _LOGGER.warning(
-                "Can't interpret '%s' as alert state (decoded protocol"
+                "Can't interpret '%s' as state change (decoded protocol"
                 " data '%s', raw data '%s')",
-                self._protocol_data.type, self._protocol_data, self._raw_data
+                self._protocol_data.event_id, self._protocol_data,
+                self._raw_data
             )
             return None
 
@@ -167,7 +176,7 @@ class G90History:
             _LOGGER.warning(
                 "Can't interpret '%s' as alert source (decoded protocol"
                 " data '%s', raw data '%s')",
-                self._protocol_data.type, self._protocol_data, self._raw_data
+                self._protocol_data.source, self._protocol_data, self._raw_data
             )
             return None
 

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -575,7 +575,7 @@ async def test_disarm(mock_device: DeviceMock) -> None:
 
 @pytest.mark.g90device(sent_data=[
     b'ISTART[200,[[50,1,5],'
-    b'[3,33,7,254,"Sensor 1",1630147285,""],'
+    b'[3,33,7,1,"Sensor 1",1630147285,""],'
     b'[2,3,0,0,"",1630142877,""],'
     b'[2,5,0,0,"",1630142871,""],'
     b'[2,4,0,0,"",1630142757,""],'
@@ -596,6 +596,29 @@ async def test_history(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
+    b'ISTART[200,[[50,1,5],'
+    b'[3,33,7,254,"Sensor 1",1630147285,""],'
+    b'[2,3,0,0,"",1630142877,""],'
+    b'[2,5,0,0,"",1630142871,""],'
+    b'[2,4,0,0,"",1630142757,""],'
+    b'[3,100,126,1,"Sensor 2",1630142297,""]]]IEND\0',
+])
+async def test_history_parsing_error(mock_device: DeviceMock) -> None:
+    """
+    Tests for processing history from the device, when the parsing error
+    occurs.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    history = await g90.history(count=5)
+    assert len(history) == 5
+    assert isinstance(history[0], G90History)
+    assert isinstance(history[0]._asdict(), dict)
+    # Wrong entry element should result in corresponding key having 'None'
+    # value
+    assert history[0]._asdict()['state'] is None
+
+
+@pytest.mark.g90device(sent_data=[
     # Simulate empty history initially
     b'ISTART[200,[[0,0,0]]]IEND\0',
     # The history records will be used to remember the timestamp of most recent
@@ -606,7 +629,7 @@ async def test_history(mock_device: DeviceMock) -> None:
     # The records will be used to simulate the device alerts, but only for
     # those newer that one above
     b'ISTART[200,[[3,1,3],'
-    b'[3,33,7,254,"Sensor 1",1630147285,""],'
+    b'[3,33,7,1,"Sensor 1",1630147285,""],'
     b'[2,3,0,0,"",1630142877,""],'
     b'[2,5,0,0,"",1630142871,""]'
     b']]IEND\0',

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -596,12 +596,14 @@ async def test_history(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[200,[[50,1,5],'
+    b'ISTART[200,[[3,1,3],'
+    # Wrong state
     b'[3,33,7,254,"Sensor 1",1630147285,""],'
-    b'[2,3,0,0,"",1630142877,""],'
-    b'[2,5,0,0,"",1630142871,""],'
-    b'[2,4,0,0,"",1630142757,""],'
-    b'[3,100,126,1,"Sensor 2",1630142297,""]]]IEND\0',
+    # Wrong source
+    b'[2,33,254,1,"Sensor 1",1630147285,""],'
+    # Wrong type
+    b'[254,33,1,1,"Sensor 1",1630147285,""]'
+    b']]IEND\0',
 ])
 async def test_history_parsing_error(mock_device: DeviceMock) -> None:
     """
@@ -610,12 +612,14 @@ async def test_history_parsing_error(mock_device: DeviceMock) -> None:
     """
     g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
     history = await g90.history(count=5)
-    assert len(history) == 5
+    assert len(history) == 3
     assert isinstance(history[0], G90History)
     assert isinstance(history[0]._asdict(), dict)
     # Wrong entry element should result in corresponding key having 'None'
     # value
     assert history[0]._asdict()['state'] is None
+    assert history[1]._asdict()['source'] is None
+    assert history[2]._asdict()['type'] is None
 
 
 @pytest.mark.g90device(sent_data=[


### PR DESCRIPTION
* `G90History` class now logs warnings when it can't interpret the incoming history entry data (for `state`, `type` and `source` properties), instead of raising `ValueError` exceptions. This is to prevent the whole history processing from failing, when the device sends data can't be interpreted correctly
* `G90History` class now uses separate dictionaries for mapping alert states and state change types, since the enums used for keys have conflicting values, otherwise the mapping would result in ambiguous values
* Added more constants to `G90NotificationTypes`, `G90AlertSources` and `G90AlertStates` enums, though most of those are guessed (there is no official documentation on the protocol)
* `G90History.state` property now uses `state` incoming field for alarm events instead of always returning `G90HistoryStates.ALARM` - it will help distinguish between different alarm scenarios, e.g. alarm due to door open vs. sensor being tampered

This should help resolving https://github.com/hostcc/hass-gs-alarm/issues/49