### PR TITLE
fix: Disallow storing empty device GUID

### DIFF
--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -473,7 +473,7 @@ class G90DeviceNotifications(DatagramProtocol):
     def device_id(self, device_id: str) -> None:
         # Under not yet identified circumstances the device ID might be empty
         # string provided by :meth:`G90Alarm.get_host_info` - disallow that
-        if not device_id or not len(device_id.strip()) == 0:
+        if not device_id or not len(device_id.strip()) != 0:
             _LOGGER.debug(
                 'Device ID is empty or contains whitespace only, not setting'
             )

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -473,7 +473,7 @@ class G90DeviceNotifications(DatagramProtocol):
     def device_id(self, device_id: str) -> None:
         # Under not yet identified circumstances the device ID might be empty
         # string provided by :meth:`G90Alarm.get_host_info` - disallow that
-        if not device_id or not len(device_id.strip()) != 0:
+        if not device_id or len(device_id.strip()) == 0:
             _LOGGER.debug(
                 'Device ID is empty or contains whitespace only, not setting'
             )

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -473,7 +473,7 @@ class G90DeviceNotifications(DatagramProtocol):
     def device_id(self, device_id: str) -> None:
         # Under not yet identified circumstances the device ID might be empty
         # string provided by :meth:`G90Alarm.get_host_info` - disallow that
-        if not device_id or not len(device_id.strip()):
+        if not device_id or not len(device_id.strip()) == 0:
             _LOGGER.debug(
                 'Device ID is empty or contains whitespace only, not setting'
             )

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -471,4 +471,12 @@ class G90DeviceNotifications(DatagramProtocol):
 
     @device_id.setter
     def device_id(self, device_id: str) -> None:
+        # Under not yet identified circumstances the device ID might be empty
+        # string provided by :meth:`G90Alarm.get_host_info` - disallow that
+        if not device_id or not len(device_id.strip()):
+            _LOGGER.debug(
+                'Device ID is empty or contains whitespace only, not setting'
+            )
+            return
+
         self._device_id = device_id

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -265,6 +265,7 @@ async def test_empty_device_guid(mock_device: DeviceMock) -> None:
     )
     # The command will fetch the host info and store the GIUD
     await g90.get_host_info()
+    g90.close()
     assert g90.device_id is None
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -250,6 +250,27 @@ async def test_wrong_host(
 @pytest.mark.g90device(
     sent_data=[
         b'ISTART[206,'
+        b'["","DUMMYPRODUCT",'
+        b'"1.2","1.1","206","206",3,3,0,2,"4242",50,100]]IEND\0',
+    ],
+)
+async def test_empty_device_guid(mock_device: DeviceMock) -> None:
+    """
+    Verifies that alert from device with empty GUID is ignored.
+    """
+    g90 = G90Alarm(
+        host=mock_device.host, port=mock_device.port,
+        notifications_local_host=mock_device.notification_host,
+        notifications_local_port=mock_device.notification_port
+    )
+    # The command will fetch the host info and store the GIUD
+    await g90.get_host_info()
+    assert g90.device_id is None
+
+
+@pytest.mark.g90device(
+    sent_data=[
+        b'ISTART[206,'
         b'["DUMMYGUID","DUMMYPRODUCT",'
         b'"1.2","1.1","206","206",3,3,0,2,"4242",50,100]]IEND\0',
     ],


### PR DESCRIPTION
* Under not yet identified circumstances the device ID might be empty string provided by `G90Alarm.get_host_info()` method - `G90DeviceNotifications.device_id` property will ignore that when being set

Should help resolving remaining issues under https://github.com/hostcc/hass-gs-alarm/issues/49