### PR TITLE
fix: Disable device GUID verification when simulating alerts from history

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -915,7 +915,10 @@ class G90Alarm(G90DeviceNotifications):
                         # notifications port
                         self._handle_alert(
                             (self._host, self._notifications_local_port),
-                            item.as_device_alert()
+                            item.as_device_alert(),
+                            # Skip verifying device GUID, since history entry
+                            # don't have it
+                            verify_device_id=False
                         )
 
                         # Record the entry as most recent one

--- a/src/pyg90alarm/device_notifications.py
+++ b/src/pyg90alarm/device_notifications.py
@@ -208,13 +208,17 @@ class G90DeviceNotifications(DatagramProtocol):
         return False
 
     def _handle_alert(
-        self, addr: Tuple[str, int], alert: G90DeviceAlert
+        self, addr: Tuple[str, int], alert: G90DeviceAlert,
+        verify_device_id: bool = True
     ) -> None:
         handled = False
 
         # Stop processing when alert is received from the device with different
-        # GUID
-        if self.device_id and alert.device_id != self.device_id:
+        # GUID (if enabled)
+        if (
+            verify_device_id and self.device_id
+            and alert.device_id != self.device_id
+        ):
             _LOGGER.error(
                 "Received alert from wrong device: expected '%s', got '%s'",
                 self.device_id, alert.device_id

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -135,6 +135,10 @@ async def test_history_parsing_error(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
+    # Host info
+    b'ISTART[206,'
+    b'["DUMMYGUID","DUMMYPRODUCT",'
+    b'"1.2","1.1","206","206",3,3,0,2,"4242",50,100]]IEND\0',
     # Simulate empty history initially
     b'ISTART[200,[[0,0,0]]]IEND\0',
     # The history records will be used to remember the timestamp of most recent
@@ -173,6 +177,9 @@ async def test_simulate_alerts_from_history(mock_device: DeviceMock) -> None:
     armdisarm_cb.side_effect = lambda *args: future_armdisarm.set_result(True)
 
     g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    # Call the method to store device GUID, so that its validation in
+    # `G90DeviceNotifications._handle_alert()` is involved
+    await g90.get_host_info()
     g90.alarm_callback = alarm_cb
     g90.armdisarm_callback = armdisarm_cb
     # Simulate device timeout exception every 2nd call to `G90Alarm.history()`


### PR DESCRIPTION
* History entries don't have device GUID, so disable its verification in `G90DeviceNotifications._handle_alert()` when simulating alerts from history

Ref. issue: https://github.com/hostcc/hass-gs-alarm/issues/49

