### PR TITLE
fix: Ensure consistent results when retrieving list of devices and sensors concurrently

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,19 +16,14 @@ isolated_build = true
 deps =
     -r requirements_dev.txt
 
-allowlist_externals =
-	cat
 commands =
     check-manifest --ignore 'tox.ini,tests/**,docs/**,.pylintrc,.readthedocs.yaml,sonar-project.properties'
     flake8 --tee --output-file=flake8.txt src/pyg90alarm/ tests/
-    pylint --output-format=parseable --output=pylint.txt src/pyg90alarm/ tests/
+    pylint --output-format=text,parseable:pylint.txt src/pyg90alarm/ tests/
     mypy --strict --cobertura-xml-report=mypy/ src/pyg90alarm/ tests/
 	  # Ensure only traces for in-repository module is processed, not for one
 	  # installed by `tox` (see above for more details)
     pytest --cov=src/pyg90alarm --cov-append --cov-report=term-missing -v tests []
-commands_post =
-	# Show the `pylint` report to the standard output, to ease fixing the issues reported
-	cat pylint.txt
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,docs


### PR DESCRIPTION


* `G90.get_sensors()` and `G90.get_devices()` methods now use locks to ensure consistent results when called concurrently. This change is necessary to prevent duplicated entries in the resulting list or redundant exchanges with the panel when the methods are called concurrently.
* `tox`: Skip using `cat` to show `pylint` report to the standard output - recent versions of the tool support such output natively