### PR TITLE
fix: Use trusted publishing for PyPi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,8 @@ jobs:
     name: Publish to PyPi
     runs-on: ubuntu-latest
     needs: [tests]
+    permissions:
+      id-token: write  # Required for trusted publishing
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -94,8 +96,8 @@ jobs:
         if: github.event_name != 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+          attestations: true
       - name: Publish the release to PyPi
         # Publish to production PyPi only happens when a release published out
         # of the main branch
@@ -106,4 +108,4 @@ jobs:
              || github.event.release.target_commitish == 'master')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          attestations: true


### PR DESCRIPTION
* Github workflow has been updated to use [trusted publishing for PyPi](https://docs.pypi.org/trusted-publishers) to avoid the need for a password.