### PR TITLE
feat: Add callbacks for tamper and door open when arming

### DIFF
--- a/src/pyg90alarm/const.py
+++ b/src/pyg90alarm/const.py
@@ -201,6 +201,7 @@ class G90AlertSources(IntEnum):
     """
     DEVICE = 0
     SENSOR = 1
+    TAMPER = 3
     REMOTE = 10
     RFID = 11
     DOORBELL = 12


### PR DESCRIPTION
* `G90DeviceNotifications` class now handles door open when arming (via `on_door_open_when_arming` method) and tamper (via additional argument to `on_alarm` method) notifications
* `G90Sensor` class now has `tamper_callback` and `door_open_when_arming_callback` properties for callbacks, which are invoked when the sensor reports the corresponding conditions. Additionally `is_tampered` and `is_door_open_when_arming` properties are added to the class to indicate those conditions on the sensor - the conditionas are reset when the panel is armed/disarmed
* `G90Alarm` class now has `tamper_callback` and `door_open_when_arming_callback` properties for callbacks similar to sensor ones above, but global on_sensor_activity