### PR TITLE
feat: Support setting user flags on sensors

### DIFF
--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -104,6 +104,7 @@ class G90SensorUserFlags(IntFlag):
     ALERT_WHEN_AWAY_AND_HOME = 32
     ALERT_WHEN_AWAY = 64
     SUPPORTS_UPDATING_SUBTYPE = 512     # Only relevant for cord sensors
+    # Flags that can be set by the user
     USER_SETTABLE = (
         ENABLED
         | ARM_DELAY


### PR DESCRIPTION
* `G90Sensor` now has a method `set_user_flag()` that allows setting user flags on the sensor. The method will ignore any flags that are not user-settable and preserve them from the existing sensor flags.
* `G90Sensor` now considers `is_tampered` and `is_door_open_when_arming` properties  when providing instance representation