### PR TITLE
feat: Added support for updating sensor/device lists w/o reinstantiating `G90Alarm`

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -268,7 +268,7 @@ class G90Alarm(G90DeviceNotifications):
     @property
     async def sensors(self) -> List[G90Sensor]:
         """
-        Returns the list of sensors configured in the device. Please note the
+        Returns the list of sensors configured in the device. Please note
         it doesn't update those from the panel except initially when the list
         if empty.
 
@@ -285,21 +285,25 @@ class G90Alarm(G90DeviceNotifications):
         """
         return await self._sensors.update()
 
-    async def find_sensor(self, idx: int, name: str) -> Optional[G90Sensor]:
+    async def find_sensor(
+        self, idx: int, name: str, exclude_unavailable: bool = True
+    ) -> Optional[G90Sensor]:
         """
         Finds sensor by index and name.
 
         :param idx: Sensor index
         :param name: Sensor name
+        :param exclude_unavailable: Flag indicating if unavailable sensors
+         should be excluded from the search
         :return: Sensor instance
         """
-        return await self._sensors.find(idx, name)
+        return await self._sensors.find(idx, name, exclude_unavailable)
 
     @property
     async def devices(self) -> List[G90Device]:
         """
         Returns the list of devices (switches) configured in the device. Please
-        note the it doesn't update those from the panel except initially when
+        note it doesn't update those from the panel except initially when
         the list if empty.
 
         :return: List of devices

--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -69,7 +69,9 @@ from .const import (
 from .base_cmd import (G90BaseCommand, G90BaseCommandData)
 from .paginated_result import G90PaginatedResult, G90PaginatedResponse
 from .entities.sensor import (G90Sensor, G90SensorTypes)
+from .entities.sensor_list import G90SensorList
 from .entities.device import G90Device
+from .entities.device_list import G90DeviceList
 from .device_notifications import (
     G90DeviceNotifications,
 )
@@ -177,10 +179,8 @@ class G90Alarm(G90DeviceNotifications):
         )
         self._host: str = host
         self._port: int = port
-        self._sensors: List[G90Sensor] = []
-        self._sensors_lock = asyncio.Lock()
-        self._devices: List[G90Device] = []
-        self._devices_lock = asyncio.Lock()
+        self._sensors = G90SensorList(self)
+        self._devices = G90DeviceList(self)
         self._notifications: Optional[G90DeviceNotifications] = None
         self._sensor_cb: Optional[SensorCallback] = None
         self._armdisarm_cb: Optional[ArmDisarmCallback] = None
@@ -268,39 +268,22 @@ class G90Alarm(G90DeviceNotifications):
     @property
     async def sensors(self) -> List[G90Sensor]:
         """
-        Property over new :meth:`.get_sensors` method, retained for
-        compatibility.
-        """
-        return await self.get_sensors()
-
-    async def get_sensors(self) -> List[G90Sensor]:
-        """
-        Provides list of sensors configured in the device. Please note the list
-        is cached upon first call, so you need to re-instantiate the class to
-        reflect any updates there.
+        Returns the list of sensors configured in the device. Please note the
+        it doesn't update those from the panel except initially when the list
+        if empty.
 
         :return: List of sensors
         """
-        # Use lock around the operation, to ensure no duplicated entries in the
-        # resulting list or redundant exchanges with panel are made when the
-        # method is called concurrently
-        async with self._sensors_lock:
-            if not self._sensors:
-                sensors = self.paginated_result(
-                    G90Commands.GETSENSORLIST
-                )
-                async for sensor in sensors:
-                    obj = G90Sensor(
-                        *sensor.data, parent=self, subindex=0,
-                        proto_idx=sensor.proto_idx
-                    )
-                    self._sensors.append(obj)
+        return await self._sensors.entities
 
-                _LOGGER.debug(
-                    'Total number of sensors: %s', len(self._sensors)
-                )
+    async def get_sensors(self) -> List[G90Sensor]:
+        """
+        Provides list of sensors configured in the device, updating them from
+        panel on each call.
 
-            return self._sensors
+        :return: List of sensors
+        """
+        return await self._sensors.update()
 
     async def find_sensor(self, idx: int, name: str) -> Optional[G90Sensor]:
         """
@@ -310,67 +293,29 @@ class G90Alarm(G90DeviceNotifications):
         :param name: Sensor name
         :return: Sensor instance
         """
-        sensors = await self.get_sensors()
-
-        # Fast lookup by direct index
-        if idx < len(sensors) and sensors[idx].name == name:
-            sensor = sensors[idx]
-            _LOGGER.debug('Found sensor via fast lookup: %s', sensor)
-            return sensor
-
-        # Fast lookup failed, perform slow one over the whole sensors list
-        for sensor in sensors:
-            if sensor.index == idx and sensor.name == name:
-                _LOGGER.debug('Found sensor: %s', sensor)
-                return sensor
-
-        _LOGGER.error('Sensor not found: idx=%s, name=%s', idx, name)
-        return None
+        return await self._sensors.find(idx, name)
 
     @property
     async def devices(self) -> List[G90Device]:
         """
-        Property over new :meth:`.get_devices` method, retained for
-        compatibility.
+        Returns the list of devices (switches) configured in the device. Please
+        note the it doesn't update those from the panel except initially when
+        the list if empty.
+
+        :return: List of devices
         """
-        return await self.get_devices()
+        return await self._devices.entities
 
     async def get_devices(self) -> List[G90Device]:
         """
-        Provides list of devices (switches) configured in the device. Please
-        note the list is cached upon first call, so you need to re-instantiate
-        the class to reflect any updates there. Multi-node devices, those
+        Provides list of devices (switches) configured in the device, updating
+        them from panel on each call. Multi-node devices, those
         having multiple ports, are expanded into corresponding number of
         resulting entries.
 
         :return: List of devices
         """
-        # See `get_sensors` method for the rationale behind the lock usage
-        async with self._devices_lock:
-            if not self._devices:
-                devices = self.paginated_result(
-                    G90Commands.GETDEVICELIST
-                )
-                async for device in devices:
-                    obj = G90Device(
-                        *device.data, parent=self, subindex=0,
-                        proto_idx=device.proto_idx
-                    )
-                    self._devices.append(obj)
-                    # Multi-node devices (first node has already been added
-                    # above
-                    for node in range(1, obj.node_count):
-                        obj = G90Device(
-                            *device.data, parent=self,
-                            subindex=node, proto_idx=device.proto_idx
-                        )
-                        self._devices.append(obj)
-
-                _LOGGER.debug(
-                    'Total number of devices: %s', len(self._devices)
-                )
-
-            return self._devices
+        return await self._devices.update()
 
     @property
     async def host_info(self) -> G90HostInfo:
@@ -637,7 +582,7 @@ class G90Alarm(G90DeviceNotifications):
 
         # Reset the tampered and door open when arming flags on all sensors
         # having those set
-        for sensor in await self.get_sensors():
+        for sensor in await self.sensors:
             if sensor.is_tampered:
                 # pylint: disable=protected-access
                 sensor._set_tampered(False)

--- a/src/pyg90alarm/entities/base_entity.py
+++ b/src/pyg90alarm/entities/base_entity.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Base entity.
+"""
+from abc import ABC, abstractmethod
+# `Self` has been introduced in Python 3.11, need to use `typing_extensions`
+# for earlier versions
+try:
+    from typing import Self  # type: ignore[attr-defined,unused-ignore]
+except ImportError:
+    from typing_extensions import Self
+
+
+class G90BaseEntity(ABC):
+    """
+    Base entity class.
+
+    Contains minimal set of method for :class:`.G90BaseList` class
+    """
+    @abstractmethod
+    def update(
+        self,
+        obj: Self  # pylint: disable=used-before-assignment
+    ) -> None:
+        """
+        Update the entity from another one.
+
+        :param obj: Object to update from.
+        """
+
+    @property
+    @abstractmethod
+    def is_unavailable(self) -> bool:
+        """
+        Check if the entity is unavailable.
+
+        :return: True if the entity is unavailable.
+        """
+
+    @is_unavailable.setter
+    @abstractmethod
+    def is_unavailable(self, value: bool) -> None:
+        """
+        Set the entity as unavailable.
+
+        :param value: Value to set.
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """
+        Get the name of the entity.
+
+        :return: Name of the entity.
+        """
+
+    @property
+    @abstractmethod
+    def index(self) -> int:
+        """
+        Get the index of the entity.
+
+        :return: Index of the entity.
+        """

--- a/src/pyg90alarm/entities/base_list.py
+++ b/src/pyg90alarm/entities/base_list.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2025 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Base entity list.
+"""
+from abc import ABC, abstractmethod
+from typing import (
+    List, AsyncGenerator, Optional, TypeVar, Generic, cast, TYPE_CHECKING,
+)
+import asyncio
+import logging
+
+from .base_entity import G90BaseEntity
+if TYPE_CHECKING:
+    from ..alarm import G90Alarm
+else:
+    # Alias G90Alarm to object avoid circular imports
+    # (`G90Alarm` -> `G90SensorList` -> `G90BaseList` -> `G90Alarm`)
+    G90Alarm = object
+
+T = TypeVar('T', bound=G90BaseEntity)
+_LOGGER = logging.getLogger(__name__)
+
+
+class G90BaseList(Generic[T], ABC):
+    """
+    Base entity list class.
+
+    :param parent: Parent alarm panel instance.
+    """
+    def __init__(self, parent: G90Alarm) -> None:
+        self._entities: List[T] = []
+        self._lock = asyncio.Lock()
+        self._parent = parent
+
+    @abstractmethod
+    async def _fetch(self) -> AsyncGenerator[T, None]:
+        """
+        Fetch the list of entities from the panel.
+
+        :return: Async generator of entities
+        """
+        yield cast(T, None)
+
+    @property
+    async def entities(self) -> List[T]:
+        """
+        Return the list of entities.
+
+        :meth:`update` is called if the list is empty.
+
+        :return: List of entities
+        """
+        # Please see below for the explanation of the lock usage
+        async with self._lock:
+            entities = self._entities
+
+        if not entities:
+            return await self.update()
+
+        return entities
+
+    async def update(self) -> List[T]:
+        """
+        Update the list of entities from the panel.
+
+        :return: List of entities
+        """
+        # Use lock around the operation, to ensure no duplicated entries in the
+        # resulting list or redundant exchanges with panel are made when the
+        # method is called concurrently
+        async with self._lock:
+            entities = self._fetch()
+
+            non_existing_entities = self._entities.copy()
+            async for entity in entities:
+                try:
+                    existing_entity_idx = self._entities.index(entity)
+                except ValueError:
+                    existing_entity_idx = None
+
+                if existing_entity_idx is not None:
+                    existing_entity = self._entities[existing_entity_idx]
+                    # Update the existing entity with the new data
+                    _LOGGER.debug(
+                        "Updating existing entity '%s' from protocol"
+                        " data '%s'", existing_entity, entity
+                    )
+
+                    self._entities[existing_entity_idx].update(entity)
+                    non_existing_entities.remove(entity)
+                else:
+                    # Add the new entity to the list
+                    _LOGGER.debug('Adding new entity: %s', entity)
+                    self._entities.append(entity)
+
+            # Mark the entities that are no longer in the list
+            for unavailable_entity in non_existing_entities:
+                _LOGGER.debug(
+                    'Marking entity as unavailable: %s', unavailable_entity
+                )
+                unavailable_entity.is_unavailable = True
+
+            _LOGGER.debug(
+                'Total number of entities: %s, unavailable: %s',
+                len(self._entities), len(non_existing_entities)
+            )
+
+            return self._entities
+
+    async def find(self, idx: int, name: str) -> Optional[T]:
+        """
+        Finds entity by index and name.
+
+        :param idx: Entity index
+        :param name: Entity name
+        :return: Entity instance
+        """
+        entities = await self.entities
+
+        # Fast lookup by direct index
+        if idx < len(entities) and entities[idx].name == name:
+            entity = entities[idx]
+            _LOGGER.debug('Found entity via fast lookup: %s', entity)
+            return entity
+
+        # Fast lookup failed, perform slow one over the whole entities list
+        for entity in entities:
+            if entity.index == idx and entity.name == name:
+                _LOGGER.debug('Found entity: %s', entity)
+                return entity
+
+        _LOGGER.error('entity not found: idx=%s, name=%s', idx, name)
+        return None

--- a/src/pyg90alarm/entities/device_list.py
+++ b/src/pyg90alarm/entities/device_list.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Device list.
+"""
+from typing import AsyncGenerator
+from .device import G90Device
+from .base_list import G90BaseList
+from ..const import G90Commands
+
+
+class G90DeviceList(G90BaseList[G90Device]):
+    """
+    Device list class.
+    """
+    async def _fetch(self) -> AsyncGenerator[G90Device, None]:
+        """
+        Fetch the list of devices from the panel.
+
+        :yields: G90Device: Device entity.
+        """
+        devices = self._parent.paginated_result(
+            G90Commands.GETDEVICELIST
+        )
+
+        async for device in devices:
+            obj = G90Device(
+                *device.data, parent=self._parent, subindex=0,
+                proto_idx=device.proto_idx
+            )
+
+            yield obj
+
+            # Multi-node devices (first node has already been handled
+            # above)
+            for node in range(1, obj.node_count):
+                obj = G90Device(
+                    *device.data, parent=self._parent,
+                    subindex=node, proto_idx=device.proto_idx
+                )
+                yield obj

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -666,7 +666,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
     @property
     def is_unavailable(self) -> bool:
         """
-        Indicates if the sensor is unavailable (e.g. not responding).
+        Indicates if the sensor is unavailable (e.g. has been removed).
         """
         return self._unavailable
 
@@ -711,6 +711,12 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         return super().__repr__() + f'({repr(self._asdict())})'
 
     def __eq__(self, value: object) -> bool:
+        """
+        Compares the sensor with another object.
+
+        :param value: Object to compare with
+        :return: If the sensor is equal to the object
+        """
         if not isinstance(value, G90Sensor):
             return False
 

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -31,6 +31,7 @@ from typing import (
 from enum import IntEnum, IntFlag
 from ..definitions.sensors import SENSOR_DEFINITIONS, SensorDefinition
 from ..const import G90Commands
+from .base_entity import G90BaseEntity
 if TYPE_CHECKING:
     from ..alarm import (
         G90Alarm, SensorStateCallback, SensorLowBatteryCallback,
@@ -171,7 +172,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-public-methods
-class G90Sensor:  # pylint:disable=too-many-instance-attributes
+class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
     """
     Interacts with sensor on G90 alarm panel.
 
@@ -208,6 +209,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         self._door_open_when_arming = False
         self._proto_idx = proto_idx
         self._extra_data: Any = None
+        self._unavailable = False
 
         self._definition: Optional[SensorDefinition] = None
         # Get sensor definition corresponds to the sensor type/subtype if any
@@ -218,6 +220,15 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             ):
                 self._definition = s_def
                 break
+
+    def update(self, obj: G90Sensor) -> None:
+        """
+        Updates sensor from another instance.
+
+        :param obj: Sensor instance to update from
+        """
+        self._protocol_data = obj.protocol_data
+        self._proto_idx = obj.proto_idx
 
     @property
     def name(self) -> str:
@@ -397,6 +408,16 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         return self._subindex
 
     @property
+    def proto_idx(self) -> int:
+        """
+        Index of the sensor within list of sensors as retrieved from the alarm
+        panel.
+
+        :return: Index of sensor in list of sensors.
+        """
+        return self._proto_idx
+
+    @property
     def supports_enable_disable(self) -> bool:
         """
         Indicates if disabling/enabling the sensor is supported.
@@ -404,6 +425,15 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         :return: Support for enabling/disabling the sensor
         """
         return self._definition is not None
+
+    @property
+    def protocol_data(self) -> G90SensorIncomingData:
+        """
+        Protocol data of the sensor.
+
+        :return: Protocol data
+        """
+        return self._protocol_data
 
     @property
     def is_wireless(self) -> bool:
@@ -532,11 +562,11 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         # when instantiated.
         _LOGGER.debug(
             'Refreshing sensor at index=%s, position in protocol list=%s',
-            self.index, self._proto_idx
+            self.index, self.proto_idx
         )
         sensors_result = self.parent.paginated_result(
             G90Commands.GETSENSORLIST,
-            start=self._proto_idx, end=self._proto_idx
+            start=self.proto_idx, end=self.proto_idx
         )
         sensors = [x.data async for x in sensors_result]
 
@@ -633,6 +663,17 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
     def extra_data(self, val: Any) -> None:
         self._extra_data = val
 
+    @property
+    def is_unavailable(self) -> bool:
+        """
+        Indicates if the sensor is unavailable (e.g. not responding).
+        """
+        return self._unavailable
+
+    @is_unavailable.setter
+    def is_unavailable(self, value: bool) -> None:
+        self._unavailable = value
+
     def _asdict(self) -> Dict[str, Any]:
         """
         Returns dictionary representation of the sensor.
@@ -644,6 +685,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             'type': self.type,
             'subtype': self.subtype,
             'index': self.index,
+            'protocol_index': self.proto_idx,
             'subindex': self.subindex,
             'node_count': self.node_count,
             'protocol': self.protocol,
@@ -657,6 +699,7 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
             'is_low_battery': self.is_low_battery,
             'is_tampered': self.is_tampered,
             'is_door_open_when_arming': self.is_door_open_when_arming,
+            'is_unavailable': self.is_unavailable,
         }
 
     def __repr__(self) -> str:
@@ -666,3 +709,14 @@ class G90Sensor:  # pylint:disable=too-many-instance-attributes
         :return: String representation
         """
         return super().__repr__() + f'({repr(self._asdict())})'
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, G90Sensor):
+            return False
+
+        return (
+            self.type == value.type
+            and self.subtype == value.subtype
+            and self.index == value.index
+            and self.name == value.name
+        )

--- a/src/pyg90alarm/entities/sensor_list.py
+++ b/src/pyg90alarm/entities/sensor_list.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025 Ilia Sotnikov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Sensor list.
+"""
+from typing import (
+    AsyncGenerator
+)
+
+from .sensor import G90Sensor
+from .base_list import G90BaseList
+from ..const import G90Commands
+
+
+class G90SensorList(G90BaseList[G90Sensor]):
+    """
+    Sensor list class.
+    """
+    async def _fetch(self) -> AsyncGenerator[G90Sensor, None]:
+        """
+        Fetch the list of sensors from the panel.
+
+        :yields: G90Sensor: Sensor entity.
+        """
+        entities = self._parent.paginated_result(
+            G90Commands.GETSENSORLIST
+        )
+
+        async for entity in entities:
+            yield G90Sensor(
+                *entity.data, parent=self._parent, subindex=0,
+                proto_idx=entity.proto_idx
+            )

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -303,6 +303,30 @@ async def test_get_sensors_update(mock_device: DeviceMock) -> None:
 
 @pytest.mark.g90device(sent_data=[
     b'ISTART[102,'
+    b'[[1,1,1],["Remote",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0',
+    b'ISTART[102,'
+    b'[[1,1,1],["Remote 2",11,0,10,1,0,33,0,0,16,1,0,""]]]IEND\0',
+])
+async def test_find_sensor(mock_device: DeviceMock) -> None:
+    """
+    Verifies updating the sensor list from the panel properly updates entitries
+    exists in the list already, and marks those are not.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensor = await g90.find_sensor(10, 'Remote')
+    assert sensor is not None
+    assert sensor.name == 'Remote'
+
+    await g90.get_sensors()
+    sensor = await g90.find_sensor(10, 'Remote')
+    assert sensor is None
+    sensor = await g90.find_sensor(10, 'Remote', exclude_unavailable=False)
+    assert sensor is not None
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
     b'[[3,1,3],["Remote 1",10,0,10,1,0,32,0,0,16,1,0,""],'
     b'["Remote 2",11,0,10,1,0,32,0,0,16,1,0,""],'
     b'["Cord 1",12,0,126,1,0,32,0,5,16,1,0,""]'

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -196,7 +196,7 @@ async def test_simulate_alerts_from_history(mock_device: DeviceMock) -> None:
     # Stop simulating the alert from history
     await g90.stop_simulating_alerts_from_history()
 
-    sensors = await g90.get_sensors()
+    sensors = await g90.sensors
     # Ensure callbacks have been called and with expected arguments
     alarm_cb.assert_called_once_with(33, 'Sensor 1', None)
     armdisarm_cb.assert_called_once_with(3)


### PR DESCRIPTION
* `G90Alarm.get_sensors()` and `G90Alarm.get_devices()` methods now fetch sensor and devices lists from the panel, without need to reinstantiate `G90Alarm`. The lists are stable, i.e. entities no longer in the panel are still retained but marked as unavailable (`.is_unavailable` property on them will return `False`). This functionality also differs from the previous versions, as those methods were caching the lists upon first retrieval, while now those are fetched upon each call to the methods.
* `G90Alarm.sensors` and `G90Alarm.devices` properties now return cached version of sensor and device lists, unless those are empty - then the properties will internall fetch those (via methods above, respectively).
* Introduced `G90BaseEntity`, `G90BaseList`, `G90SensorList` and `G90DeviceList` classes to support the above functionality.