### PR TITLE
fix: `G90Alarm.use_cloud_notifications()` type annotations

### DIFF
--- a/src/pyg90alarm/alarm.py
+++ b/src/pyg90alarm/alarm.py
@@ -1064,8 +1064,8 @@ class G90Alarm(G90NotificationProtocol):
     async def use_cloud_notifications(
         self, cloud_local_host: str = CLOUD_NOTIFICATIONS_HOST,
         cloud_local_port: int = CLOUD_NOTIFICATIONS_PORT,
-        upstream_host: str = REMOTE_CLOUD_HOST,
-        upstream_port: int = REMOTE_CLOUD_PORT,
+        upstream_host: Optional[str] = REMOTE_CLOUD_HOST,
+        upstream_port: Optional[int] = REMOTE_CLOUD_PORT,
         keep_single_connection: bool = True
     ) -> None:
         """


### PR DESCRIPTION
* `G90Alarm.use_cloud_notifications()` method type annotations were updated to use `Optional` for `upstream_host` and `upstream_port` parameters, to align with `G90CloudNotifications` class constructor