### PR TITLE
feat: Improved handling of sensor user flags and panel alert modes

### DIFF
--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -50,7 +50,7 @@ class G90Device(G90Sensor):
                                   [self.index, 1, self.subindex])
 
     @property
-    def supports_enable_disable(self) -> bool:
+    def supports_updates(self) -> bool:
         """
         Indicates if disabling/enabling the device (relay) is supported.
 
@@ -64,12 +64,12 @@ class G90Device(G90Sensor):
         # mostly.
         return False
 
-    async def set_enabled(self, value: bool) -> None:
+    async def delete(self) -> None:
         """
-        Changes the disabled/enabled state of the device (relay).
-
-        :param value: Whether to enable or disable the device
+        Deletes the device (relay) from the G90 alarm panel.
         """
-        _LOGGER.warning(
-            'Manipulating with enable/disable for device is unsupported'
-        )
+        _LOGGER.debug("Deleting device: %s", self)
+        # Mark the device as unavailable
+        self.is_unavailable = True
+        # Delete the device from the alarm panel
+        await self.parent.command(G90Commands.DELDEVICE, [self.index])

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -52,7 +52,7 @@ class G90SensorCommonData:  # pylint:disable=too-many-instance-attributes
     type_id: int
     subtype: int
     timeout: int
-    user_flag_data: int
+    user_flags_data: int
     baudrate: int
     protocol_id: int
     reserved_data: int
@@ -115,6 +115,35 @@ class G90SensorUserFlags(IntFlag):
         | ALERT_WHEN_AWAY_AND_HOME
         | ALERT_WHEN_AWAY
     )
+
+
+class G90SensorAlertModes(IntEnum):
+    """
+    Dedicated alert modes for the sensors (subset of user flags).
+    """
+    ALERT_ALWAYS = 0
+    ALERT_WHEN_AWAY = 1
+    ALERT_WHEN_AWAY_AND_HOME = 2
+
+
+# Mapping of relevant user flags to alert modes
+ALERT_MODES_MAP_BY_FLAG = {
+    # No 'when away' or 'when away and home' flag set means 'alert always
+    G90SensorUserFlags.NONE:
+        G90SensorAlertModes.ALERT_ALWAYS,
+    G90SensorUserFlags.ALERT_WHEN_AWAY:
+        G90SensorAlertModes.ALERT_WHEN_AWAY,
+    G90SensorUserFlags.ALERT_WHEN_AWAY_AND_HOME:
+        G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME,
+}
+
+# Reversed mapping of alert modes to corresponding user flags
+ALERT_MODES_MAP_BY_VALUE = dict(
+    zip(
+        ALERT_MODES_MAP_BY_FLAG.values(),
+        ALERT_MODES_MAP_BY_FLAG.keys()
+    )
+)
 
 
 class G90SensorProtocols(IntEnum):
@@ -364,11 +393,21 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
     @property
     def user_flag(self) -> G90SensorUserFlags:
         """
+        User flags for the sensor, retained for compatibility - please use
+        `:attr:user_flags` instead.
+
+        :return: User flags
+        """
+        return self.user_flags
+
+    @property
+    def user_flags(self) -> G90SensorUserFlags:
+        """
         User flags for the sensor (disabled/enabled, arming type etc).
 
         :return: User flags
         """
-        return G90SensorUserFlags(self._protocol_data.user_flag_data)
+        return G90SensorUserFlags(self._protocol_data.user_flags_data)
 
     @property
     def node_count(self) -> int:
@@ -418,13 +457,32 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         return self._proto_idx
 
     @property
+    def supports_updates(self) -> bool:
+        """
+        Indicates if the sensor supports updates.
+
+        :return: Support for updates
+        """
+        if not self._definition:
+            _LOGGER.warning(
+                'Manipulating with user flags for sensor index=%s'
+                ' is unsupported - no sensor definition for'
+                ' type=%s, subtype=%s',
+                self.index,
+                self._protocol_data.type_id,
+                self._protocol_data.subtype
+            )
+            return False
+        return True
+
+    @property
     def supports_enable_disable(self) -> bool:
         """
         Indicates if disabling/enabling the sensor is supported.
 
         :return: Support for enabling/disabling the sensor
         """
-        return self._definition is not None
+        return self.supports_updates
 
     @property
     def protocol_data(self) -> G90SensorIncomingData:
@@ -518,16 +576,14 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         )
         self._door_open_when_arming = value
 
-    @property
-    def enabled(self) -> bool:
-        """
-        Indicates if the sensor is enabled.
-
-        :return: If sensor is enabled
-        """
-        return self.user_flag & G90SensorUserFlags.ENABLED != 0
-
     async def set_user_flag(self, value: G90SensorUserFlags) -> None:
+        """
+        Sets user flags of the sensor, retained for compatibility - please use
+        `:meth:set_user_flags` instead.
+        """
+        await self.set_user_flags(value)
+
+    async def set_user_flags(self, value: G90SensorUserFlags) -> None:
         """
         Sets user flags of the sensor.
 
@@ -535,26 +591,21 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
           :attr:`.G90SensorUserFlags.USER_SETTABLE` will be ignored and
           preserved from existing sensor flags.
         """
+        if not self.supports_updates:
+            return
+
+        # Checking private attribute directly, since `mypy` doesn't recognize
+        # the check for sensor definition is done over
+        # `self.supports_updates` property
+        if not self._definition:
+            return
+
         if value & ~G90SensorUserFlags.USER_SETTABLE:
             _LOGGER.warning(
                 'User flags for sensor index=%s contain non-user settable'
                 ' flags, those will be ignored: %s',
                 self.index, repr(value & ~G90SensorUserFlags.USER_SETTABLE)
             )
-        # Checking private attribute directly, since `mypy` doesn't recognize
-        # the check for sensor definition to be defined if done over
-        # `self.supports_enable_disable` property
-        if not self._definition:
-            _LOGGER.warning(
-                'Manipulating with user flags for sensor index=%s'
-                ' is unsupported - no sensor definition for'
-                ' type=%s, subtype=%s',
-                self.index,
-                self._protocol_data.type_id,
-                self._protocol_data.subtype
-            )
-
-            return
 
         # Refresh actual sensor data from the alarm panel before modifying it.
         # This implies the sensor is at the same position within sensor list
@@ -593,24 +644,32 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             )
             return
 
-        prev_user_flag = self.user_flag
+        prev_user_flags = self.user_flags
 
         # Re-instantiate the protocol data with modified user flags
         _data = asdict(self._protocol_data)
-        _data['user_flag_data'] = (
+        _data['user_flags_data'] = (
             # Preserve flags that are not user-settable
-            self.user_flag & ~G90SensorUserFlags.USER_SETTABLE
+            self.user_flags & ~G90SensorUserFlags.USER_SETTABLE
         ) | (
             # Combine them with the new user-settable flags
             value & G90SensorUserFlags.USER_SETTABLE
         )
         self._protocol_data = self._protocol_incoming_data_kls(**_data)
 
+        if self.user_flags == prev_user_flags:
+            _LOGGER.debug(
+                'Sensor index=%s: user flags %s have not changed,'
+                ' skipping update',
+                self._protocol_data.index, repr(prev_user_flags)
+            )
+            return
+
         _LOGGER.debug(
-            'Sensor index=%s: previous user_flag %s, resulting user_flag %s',
+            'Sensor index=%s: previous user flags %s, resulting flags %s',
             self._protocol_data.index,
-            repr(prev_user_flag),
-            repr(self.user_flag)
+            repr(prev_user_flags),
+            repr(self.user_flags)
         )
 
         # Generate protocol data from write operation, deriving values either
@@ -623,7 +682,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             type_id=self._protocol_data.type_id,
             subtype=self._protocol_data.subtype,
             timeout=self._protocol_data.timeout,
-            user_flag_data=self._protocol_data.user_flag_data,
+            user_flags_data=self._protocol_data.user_flags_data,
             baudrate=self._protocol_data.baudrate,
             protocol_id=self._protocol_data.protocol_id,
             reserved_data=self._definition.reserved_data,
@@ -637,19 +696,109 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             G90Commands.SETSINGLESENSOR, list(astuple(outgoing_data))
         )
 
+    def get_flag(self, flag: G90SensorUserFlags) -> bool:
+        """
+        Gets the user flag for the sensor.
+
+        :param flag: User flag to get
+        :return: User flag value
+        """
+        return flag in self.user_flag
+
+    async def set_flag(
+        self, flag: G90SensorUserFlags, value: bool
+    ) -> None:
+        """
+        Sets the user flag for the sensor.
+
+        :param flag: User flag to set
+        :param value: New value for the user flag
+        """
+        # Skip updating the flag if it has the desired value
+        if self.get_flag(flag) == value:
+            _LOGGER.debug(
+                'Sensor index=%s: user flag %s has not changed,'
+                ' skipping update',
+                self._protocol_data.index, repr(flag)
+            )
+            return
+
+        # Invert corresponding user flag and set it
+        user_flag = self.user_flag ^ flag
+        await self.set_user_flag(user_flag)
+
+    @property
+    def enabled(self) -> bool:
+        """
+        Indicates if the sensor is enabled, using `:meth:get_user_flag` instead
+        is preferred.
+
+        :return: If sensor is enabled
+        """
+        return self.get_flag(G90SensorUserFlags.ENABLED)
+
     async def set_enabled(self, value: bool) -> None:
         """
-        Sets the sensor enabled/disabled.
-        """
+        Sets the sensor enabled/disabled, using `:meth:set_user_flag` instead
+        is preferred.
 
-        # Modify the value of the user flag setting enabled/disabled one
-        # appropriately.
-        user_flag = self.user_flag
-        if value:
-            user_flag |= G90SensorUserFlags.ENABLED
-        else:
-            user_flag &= ~G90SensorUserFlags.ENABLED
-        await self.set_user_flag(user_flag)
+        :param value: New the sensor should be enabled
+        """
+        await self.set_flag(G90SensorUserFlags.ENABLED, value)
+
+    @property
+    def alert_mode(self) -> G90SensorAlertModes:
+        """
+        Alert mode for the sensor.
+
+        :return: Alert mode
+        """
+        # Filter out irrelevant flags
+        mode = self.user_flag & (
+            G90SensorUserFlags.ALERT_WHEN_AWAY
+            | G90SensorUserFlags.ALERT_WHEN_AWAY_AND_HOME
+        )
+        # Map the relevant user flags to alert mode
+        result = ALERT_MODES_MAP_BY_FLAG.get(mode, None)
+
+        if result is None:
+            raise ValueError(
+                f"Unknown alert mode for sensor {self.name}: {mode}"
+                f" (user flag: {self.user_flag})"
+            )
+
+        return result
+
+    async def set_alert_mode(self, value: G90SensorAlertModes) -> None:
+        """
+        Sets the sensor alert mode.
+        """
+        # Skip update if the value is already set to the requested one
+        if self.alert_mode == value:
+            _LOGGER.debug(
+                'Sensor index=%s: alert mode %s has not changed,'
+                ' skipping update',
+                self._protocol_data.index, repr(value)
+            )
+            return
+
+        # Map the alert mode to user flag value
+        result = ALERT_MODES_MAP_BY_VALUE.get(value, None)
+
+        if result is None:
+            raise ValueError(
+                f"Attempting to set alert mode for sensor {self.name} to"
+                f" unknown value '{value}'"
+            )
+
+        # Add the mapped value over the user flags, filtering out previous
+        # value of the alert mode
+        user_flags = self.user_flag & ~(
+            G90SensorUserFlags.ALERT_WHEN_AWAY
+            | G90SensorUserFlags.ALERT_WHEN_AWAY_AND_HOME
+        ) | result
+        # Set the updated user flags
+        await self.set_user_flag(user_flags)
 
     @property
     def extra_data(self) -> Any:
@@ -674,6 +823,19 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
     def is_unavailable(self, value: bool) -> None:
         self._unavailable = value
 
+    async def delete(self) -> None:
+        """
+        Deletes the sensor from the alarm panel.
+        """
+        _LOGGER.debug("Deleting sensor: %s", self)
+
+        # Mark the sensor as unavailable
+        self.is_unavailable = True
+        # Delete the sensor from the alarm panel
+        await self.parent.command(
+            G90Commands.DELSENSOR, [self.index]
+        )
+
     def _asdict(self) -> Dict[str, Any]:
         """
         Returns dictionary representation of the sensor.
@@ -693,8 +855,15 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             'user_flag': self.user_flag,
             'reserved': self.reserved,
             'extra_data': self.extra_data,
-            'enabled': self.enabled,
-            'supports_enable_disable': self.supports_enable_disable,
+            'enabled': self.get_flag(G90SensorUserFlags.ENABLED),
+            'detect_door': self.get_flag(G90SensorUserFlags.DETECT_DOOR),
+            'door_chime': self.get_flag(G90SensorUserFlags.DOOR_CHIME),
+            'independent_zone': self.get_flag(
+                G90SensorUserFlags.INDEPENDENT_ZONE
+            ),
+            'arm_delay': self.get_flag(G90SensorUserFlags.ARM_DELAY),
+            'alert_mode': self.alert_mode,
+            'supports_updates': self.supports_updates,
             'is_wireless': self.is_wireless,
             'is_low_battery': self.is_low_battery,
             'is_tampered': self.is_tampered,

--- a/src/pyg90alarm/local/config.py
+++ b/src/pyg90alarm/local/config.py
@@ -22,8 +22,13 @@
 Represents various configuration aspects of the alarm panel.
 """
 from __future__ import annotations
-from enum import IntFlag
+from typing import TYPE_CHECKING, Optional
+import logging
 from dataclasses import dataclass
+from enum import IntFlag
+from ..const import G90Commands
+if TYPE_CHECKING:
+    from ..alarm import G90Alarm
 
 
 class G90AlertConfigFlags(IntFlag):
@@ -44,16 +49,110 @@ class G90AlertConfigFlags(IntFlag):
     UNKNOWN2 = 8192
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 @dataclass
-class G90AlertConfig:
+class G90AlertConfigData:
     """
-    Represents alert configuration as received from the alarm panel.
+    Represents alert configuration data as received from the alarm panel.
     """
     flags_data: int
 
     @property
     def flags(self) -> G90AlertConfigFlags:
         """
-        :return: Symbolic names for corresponding flag bits
+        :return: The alert configuration flags
         """
         return G90AlertConfigFlags(self.flags_data)
+
+    @flags.setter
+    def flags(self, value: G90AlertConfigFlags) -> None:
+        """
+        :param value: The alert configuration flags
+        """
+        self.flags_data = value.value
+
+
+class G90AlertConfig:
+    """
+    Represents alert configuration as received from the alarm panel.
+    """
+    def __init__(self, parent: G90Alarm) -> None:
+        self._alert_config: Optional[G90AlertConfigData] = None
+        self.parent = parent
+
+    async def _get(self) -> G90AlertConfigData:
+        """
+        Retrieves the alert configuration flags from the device. Please note
+        the configuration is cached upon first call, so you need to
+        re-instantiate the class to reflect any updates there.
+
+        :return: The alerts configured
+        """
+        if not self._alert_config:
+            self._alert_config = await self._get_uncached()
+        return self._alert_config
+
+    async def _get_uncached(self) -> G90AlertConfigData:
+        """
+        Retrieves the alert configuration flags directly from the device.
+
+        :return: The alerts configured
+        """
+        _LOGGER.debug('Retrieving alert configuration from the device')
+        res = await self.parent.command(G90Commands.GETNOTICEFLAG)
+        data = G90AlertConfigData(*res)
+        _LOGGER.debug(
+            'Alert configuration: %s, flags: %s', data,
+            repr(data.flags)
+        )
+        return data
+
+    async def set(self, flags: G90AlertConfigFlags) -> None:
+        """
+        Sets the alert configuration flags on the device.
+        """
+        # Use uncached method retrieving the alert configuration, to ensure the
+        # actual value retrieved from the device
+        _LOGGER.debug('Setting alert configuration to %s', repr(flags))
+        alert_config = await self._get_uncached()
+        if alert_config != self._alert_config:
+            _LOGGER.warning(
+                'Alert configuration changed externally,'
+                ' overwriting (read "%s", will be set to "%s")',
+                repr(alert_config), repr(flags)
+            )
+        await self.parent.command(G90Commands.SETNOTICEFLAG, [flags.value])
+        # Update the alert configuration stored
+        (await self._get()).flags = flags
+
+    async def get_flag(self, flag: G90AlertConfigFlags) -> bool:
+        """
+        :param flag: The flag to check
+        """
+        return flag in await self.flags
+
+    async def set_flag(self, flag: G90AlertConfigFlags, value: bool) -> None:
+        """
+        :param flag: The flag to set
+        :param value: The value to set
+        """
+        # Skip updating the flag if it has the desired value
+        if await self.get_flag(flag) == value:
+            _LOGGER.debug(
+                'Flag %s already set to %s, skipping update',
+                repr(flag), value
+            )
+            return
+
+        # Invert corresponding user flag and set it
+        flags = await self.flags ^ flag
+        await self.set(flags)
+
+    @property
+    async def flags(self) -> G90AlertConfigFlags:
+        """
+        :return: Symbolic names for corresponding flag bits
+        """
+        return (await self._get()).flags

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+"""
+Tests for the G90AlertConfig class.
+"""
+from __future__ import annotations
+import pytest
+from pyg90alarm.alarm import (
+    G90Alarm,
+)
+from pyg90alarm.local.config import (
+    G90AlertConfigFlags,
+)
+from .device_mock import DeviceMock
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[117,[1]]IEND\0',
+])
+async def test_alert_config(mock_device: DeviceMock) -> None:
+    """
+    Tests for retrieving alert configuration from the device.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    config = await g90.alert_config.flags
+    assert await mock_device.recv_data == [b'ISTART[117,117,""]IEND\0']
+    assert isinstance(config, G90AlertConfigFlags)
+    assert G90AlertConfigFlags.AC_POWER_FAILURE in config
+
+
+@pytest.mark.g90device(sent_data=[
+    b"ISTART[117,[1]]IEND\0",
+    b"ISTART[117,[3]]IEND\0",
+    b"ISTARTIEND\0",
+])
+async def test_set_alert_config(mock_device: DeviceMock) -> None:
+    """
+    Tests for setting alert configuration to the the device.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    await g90.alert_config.set_flag(G90AlertConfigFlags.AC_POWER_FAILURE, True)
+    await g90.alert_config.set_flag(G90AlertConfigFlags.HOST_LOW_VOLTAGE, True)
+    assert await mock_device.recv_data == [
+        b'ISTART[117,117,""]IEND\0',
+        b'ISTART[117,117,""]IEND\0',
+        b"ISTART[116,116,[116,[9]]]IEND\0",
+    ]
+    # Validate we retrieve same alert configuration just has been set
+    assert await g90.alert_config.get_flag(
+        G90AlertConfigFlags.AC_POWER_FAILURE) is True
+    assert await g90.alert_config.get_flag(
+        G90AlertConfigFlags.HOST_LOW_VOLTAGE) is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,410 @@
+"""
+Tests for the G90Sensor class.
+"""
+from __future__ import annotations
+import pytest
+from pyg90alarm.alarm import (
+    G90Alarm,
+)
+from pyg90alarm.entities.sensor import (
+    G90Sensor, G90SensorUserFlags, G90SensorAlertModes,
+)
+from .device_mock import DeviceMock
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[3,1,3],["Remote 1",10,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 2",11,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Cord 1",12,0,126,1,0,32,0,5,16,1,0,""]'
+    b']]IEND\0',
+])
+async def test_multiple_sensors_shorter_than_page(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for retrieving multiple sensors from the panel, while the number of
+    those is shorter than a single page.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+    ]
+    assert len(sensors) == 3
+    assert isinstance(sensors, list)
+    assert isinstance(sensors[0], G90Sensor)
+    assert sensors[0].name == 'Remote 1'
+    assert sensors[0].index == 10
+    assert sensors[0].is_wireless is True
+    assert isinstance(sensors[1], G90Sensor)
+    assert sensors[1].name == 'Remote 2'
+    assert sensors[1].index == 11
+    assert sensors[1].is_wireless is True
+    assert isinstance(sensors[2], G90Sensor)
+    assert sensors[2].name == 'Cord 1'
+    assert sensors[2].index == 12
+    assert sensors[2].is_wireless is False
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[11,1,10],'
+    b'["Remote 1",10,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 2",11,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 3",12,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 4",13,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 5",14,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 6",15,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 7",16,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 8",17,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 9",18,0,10,1,0,32,0,0,16,1,0,""],'
+    b'["Remote 10",19,0,10,1,0,32,0,0,16,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[11,11,1],'
+    b'["Remote 11",20,0,10,1,0,32,0,0,16,1,0,""]'
+    b']]IEND\0',
+])
+async def test_multiple_sensors_longer_than_page(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for retrieving multiple sensors from the panel, while the number of
+    those is longer than a single page.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[11,11]]]IEND\0',
+    ]
+    assert len(sensors) == 11
+    assert isinstance(sensors, list)
+    assert isinstance(sensors[0], G90Sensor)
+    assert sensors[0].name == 'Remote 1'
+    assert sensors[0].index == 10
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],["Remote",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0',
+])
+async def test_single_sensor(mock_device: DeviceMock) -> None:
+    """
+    Tests for retrieving single sensor from the panel.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+    ]
+    assert len(sensors) == 1
+    assert isinstance(sensors, list)
+    assert isinstance(sensors[0], G90Sensor)
+    assert sensors[0].name == 'Remote'
+    assert sensors[0].index == 10
+    assert isinstance(sensors[0]._asdict(), dict)
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[2,1,2],'
+    b'["Night Light1",11,0,138,0,0,63,0,0,17,1,0,""],'
+    b'["Night Light2",10,0,138,0,0,63,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[2,2,1],'
+    b'["Night Light2",10,0,138,0,0,63,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+@pytest.mark.parametrize(
+    'flag,value_before,value_after,expected_data', [
+        pytest.param(
+            G90SensorUserFlags.ENABLED, True, False, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,62,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='enabled',
+        ),
+        pytest.param(
+            G90SensorUserFlags.ENABLED, True, True, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+            ],
+            id='enabled-not-changed',
+        ),
+        pytest.param(
+            G90SensorUserFlags.ARM_DELAY, True, False, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,61,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='arm_delay',
+        ),
+        pytest.param(
+            G90SensorUserFlags.DETECT_DOOR, True, False, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,59,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='detect_door',
+        ),
+        pytest.param(
+            G90SensorUserFlags.DOOR_CHIME, True, False, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,55,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='door_chime',
+        ),
+        pytest.param(
+            G90SensorUserFlags.INDEPENDENT_ZONE, True, False, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,47,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='independent_zone',
+        ),
+    ]
+)
+async def test_sensor_user_flag(
+    flag: G90SensorUserFlags,
+    value_before: bool,
+    value_after: bool,
+    expected_data: list[bytes], mock_device: DeviceMock
+) -> None:
+    """
+    Tests for settings flags on a sensor.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    assert sensors[1].get_flag(flag) == value_before
+    await sensors[1].set_flag(flag, value_after)
+    assert sensors[1].get_flag(flag) == value_after
+    assert await mock_device.recv_data == expected_data
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[2,1,2],'
+    b'["Night Light1",11,0,138,0,0,63,0,0,17,1,0,""],'
+    b'["Night Light2",10,0,138,0,0,63,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[2,2,1],'
+    b'["Night Light2",10,0,138,0,0,63,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+@pytest.mark.parametrize(
+    'value_before,value_after,expected_response', [
+        pytest.param(
+            G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME,
+            G90SensorAlertModes.ALERT_ALWAYS, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,31,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='always',
+        ),
+        pytest.param(
+            G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME,
+            G90SensorAlertModes.ALERT_WHEN_AWAY, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[2,2]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,95,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='when-away',
+        ),
+        pytest.param(
+            G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME,
+            G90SensorAlertModes.ALERT_WHEN_AWAY_AND_HOME, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+            ],
+            id='not-changed',
+        ),
+    ]
+)
+async def test_sensor_user_alert_mode(
+    value_before: G90SensorAlertModes,
+    value_after: G90SensorAlertModes,
+    expected_response: list[bytes], mock_device: DeviceMock
+) -> None:
+    """
+    Tests for setting alert mode on a sensor.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    assert sensors[1].alert_mode == value_before
+    await sensors[1].set_alert_mode(value_after)
+    assert sensors[1].alert_mode == value_after
+    assert await mock_device.recv_data == expected_response
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[2,1,2],'
+    b'["Night Light1",11,0,138,0,0,33,0,0,17,1,0,""],'
+    b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[2,2,1],'
+    b'["Night Light2",10,0,138,0,0,1,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+async def test_sensor_disable_externally_modified(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for disabling a sensor that has been modified externally.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+    assert sensors[1].enabled
+    await sensors[1].set_enabled(False)
+    assert sensors[1].enabled
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[2,2]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],["Unsupported",10,0,255,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+async def test_sensor_unsupported_disable(mock_device: DeviceMock) -> None:
+    """
+    Tests for disabling an unsupported sensor.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+    assert sensors[0].enabled
+    await sensors[0].set_enabled(False)
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[2,1,2],'
+    b'["Night Light1",11,0,138,0,0,33,0,0,17,1,0,""],'
+    b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,[[2,2,0]]]IEND\0',
+])
+async def test_sensor_disable_sensor_not_found_on_refresh(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for disabling a sensor that is not found on refresh.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+
+    sensors = await g90.sensors
+    assert sensors[1].enabled
+    await sensors[1].set_enabled(False)
+    assert sensors[1].enabled
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[2,2]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+@pytest.mark.parametrize(
+    'flags,expected_response', [
+        pytest.param(
+            # Intentionally contains non-user settable flag, which should be
+            # ignored and not configured for the sensor that initial doesn't
+            # have it set
+            G90SensorUserFlags.INDEPENDENT_ZONE | G90SensorUserFlags.ARM_DELAY
+            | G90SensorUserFlags.SUPPORTS_UPDATING_SUBTYPE, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[1,1]]]IEND\0',
+                b'ISTART[103,103,[103,'
+                b'["Night Light2",10,0,138,0,0,18,0,0,17,1,0,2,"060A0600"]'
+                b']]IEND\0',
+            ],
+            id='set-flags',
+        ),
+        pytest.param(
+            G90SensorUserFlags.ALERT_WHEN_AWAY_AND_HOME
+            | G90SensorUserFlags.ENABLED, [
+                b'ISTART[102,102,[102,[1,10]]]IEND\0',
+                b'ISTART[102,102,[102,[1,1]]]IEND\0',
+            ],
+            id='set-flags-not-changed',
+        ),
+    ]
+)
+async def test_sensor_set_user_flags(
+    flags: G90SensorUserFlags, expected_response: list[bytes],
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for setting user flags on a sensor.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].set_user_flags(flags)
+    assert await mock_device.recv_data == expected_response
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Night Light2",10,0,138,0,0,33,0,0,17,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+])
+async def test_sensor_delete(mock_device: DeviceMock) -> None:
+    """
+    Tests deleting the sensor.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].delete()
+    assert sensors[0].is_unavailable
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[131,131,[131,[10]]]IEND\0',
+    ]


### PR DESCRIPTION
* `G90Sensor` class now supports manipulating over individual user flags via newly added `.get_flag()` and `.set_flag()` methods. Also, alert modes for the sensor could be manipulated via `.alert_mode` property and `.set_alert_mode()` method with no need to accound for rest of user flags. Finally, `.user_flag` and `.set_user_flag()` are now deprecated in favor of `.user_flags` and `.set_user_flags()`, respectively.

* `G90AlarmConfig` class has been extended to allow manipulating over individual alert flags via `.get_flag()` and `.set_flag()` methods. Also, `.alert_config` property has been added to `G90Alarm` class to allow retrieving the alert configuration object. The `G90Alarm.get_alert_config()` and `G90Alarm.set_alert_config()` are bow deprecated in favor of `.alert_config` and methods of `G90AlertConfig` class.

* Tests for the changes above are now in separate `tests/test_sensor.py` and `tests/test_config.py` files.

* Fixed typos in `README.rst`