### PR TITLE
chore(RTD): Update runner to Ubuntu 24.04 and Python 3.14

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,9 @@
 
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.14"
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,13 @@
 sphinx-rtd-theme
 enum-tools[sphinx]
 sphinx-autodoc-typehints==2.3.0; python_version < '3.11'
-sphinx-autodoc-typehints==3.6.2; python_version >= '3.11'
+# `spinx-autodoc-typehints` 3.6+ require Sphinx 9.x - pin it to 3.5.2 last
+# supporting Sphinx 8.x (see below for the reason)
+sphinx-autodoc-typehints==3.5.2; python_version >= '3.11'
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability
-sphinx==8.2.3 # enum_tools.autoenum doesn't support sphinx 9.x yet, https://github.com/domdfcoding/enum_tools/issues/118
+# enum_tools.autoenum doesn't support sphinx 9.x yet,
+# https://github.com/domdfcoding/enum_tools/issues/118
+sphinx==8.2.3
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ enum-tools[sphinx]
 sphinx-autodoc-typehints==2.3.0; python_version < '3.11'
 sphinx-autodoc-typehints==3.6.2; python_version >= '3.11'
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability
-sphinx>=3.3.0 # not directly required, pinned by Snyk to avoid a vulnerability
+sphinx==8.2.3 # enum_tools.autoenum doesn't support sphinx 9.x yet, https://github.com/domdfcoding/enum_tools/issues/118
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
* Due to ReadTheDocs (RTD) [deprecating Ubuntu 20.04 runner](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/) the configuration has been updated to use Ubuntu 24.04 instead
* To complete on the updates the Python version for RTD has been updated to 3.14