### PR TITLE
feat: Support renaming sensors/switches

### DIFF
--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -38,6 +38,27 @@ class G90Device(G90Sensor):
     Interacts with device (relay) on G90 alarm panel.
     """
     @property
+    def _get_list_command(self) -> G90Commands:
+        """
+        Panel command used to refresh this device.
+        """
+        return G90Commands.GETDEVICELIST
+
+    @property
+    def _set_single_command(self) -> G90Commands:
+        """
+        Panel command used to write this device.
+        """
+        return G90Commands.SETSINGLEDEVICE
+
+    @property
+    def _entity_kind(self) -> str:
+        """
+        Entity kind used for logging.
+        """
+        return 'device'
+
+    @property
     def definition(self) -> Optional[G90PeripheralDefinition]:
         """
         Returns the definition for the device.
@@ -71,20 +92,11 @@ class G90Device(G90Sensor):
         await self.parent.command(G90Commands.CONTROLDEVICE,
                                   [self.index, 1, self.subindex])
 
-    @property
-    def supports_updates(self) -> bool:
+    async def _refresh_entities(self) -> None:
         """
-        Indicates if disabling/enabling the device (relay) is supported.
-
-        :return: Support for enabling/disabling the device
+        Refreshes cached devices from the panel.
         """
-        # No support for manipulating of disable/enabled for the device, since
-        # single protocol entity read from the G90 alarm panel results in
-        # multiple `G90Device` instances and changing the state would
-        # subsequently require a design change to allow multiple entities to
-        # reflect that. Multiple device entities are for multi-channel relays
-        # mostly.
-        return False
+        await self.parent.get_devices()
 
     async def delete(self) -> None:
         """

--- a/src/pyg90alarm/entities/device.py
+++ b/src/pyg90alarm/entities/device.py
@@ -102,7 +102,7 @@ class G90Device(G90Sensor):
         """
         Deletes the device (relay) from the G90 alarm panel.
         """
-        _LOGGER.debug("Deleting device: %s", self)
+        _LOGGER.debug("Deleting %s: %s", self._entity_kind, self)
         # Mark the device as unavailable
         self.is_unavailable = True
         # Delete the device from the alarm panel

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -353,9 +353,9 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         :param value: Occupancy state
         """
         _LOGGER.debug(
-            "Setting occupancy for sensor index=%s: '%s' %s"
+            "Setting occupancy for %s index=%s: '%s' %s"
             " (previous value: %s)",
-            self.index, self.name, value, self._occupancy
+            self._entity_kind, self.index, self.name, value, self._occupancy
         )
         self._occupancy = value
 
@@ -482,10 +482,11 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         """
         if not self.definition:
             _LOGGER.debug(
-                'Manipulating sensor at index=%s'
-                ' is unsupported - no sensor definition for'
+                'Manipulating %s at index=%s'
+                ' is unsupported - no definition for'
                 ' type=%s, subtype=%s, protocol=%s',
-                self.index, self.type, self.subtype, self.protocol
+                self._entity_kind, self.index, self.type, self.subtype,
+                self.protocol
             )
             return False
         return True
@@ -535,9 +536,9 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         :param value: Low battery state
         """
         _LOGGER.debug(
-            "Setting low battery for sensor index=%s '%s': %s"
+            "Setting low battery for %s index=%s '%s': %s"
             " (previous value: %s)",
-            self.index, self.name, value, self._low_battery
+            self._entity_kind, self.index, self.name, value, self._low_battery
         )
         self._low_battery = value
 
@@ -560,9 +561,9 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         :param value: Tamper state
         """
         _LOGGER.debug(
-            "Setting tamper for sensor index=%s '%s': %s"
+            "Setting tamper for %s index=%s '%s': %s"
             " (previous value: %s)",
-            self.index, self.name, value, self._tampered
+            self._entity_kind, self.index, self.name, value, self._tampered
         )
         self._tampered = value
 
@@ -585,9 +586,10 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         :param value: Door open state
         """
         _LOGGER.debug(
-            "Setting door open when arming for sensor index=%s '%s': %s"
+            "Setting door open when arming for %s index=%s '%s': %s"
             " (previous value: %s)",
-            self.index, self.name, value, self._door_open_when_arming
+            self._entity_kind, self.index, self.name, value,
+            self._door_open_when_arming
         )
         self._door_open_when_arming = value
 
@@ -608,9 +610,10 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         """
         if value & ~G90SensorUserFlags.USER_SETTABLE:
             _LOGGER.debug(
-                'User flags for sensor index=%s contain non-user settable'
+                'User flags for %s index=%s contain non-user settable'
                 ' flags, those will be ignored: %s',
-                self.index, repr(value & ~G90SensorUserFlags.USER_SETTABLE)
+                self._entity_kind, self.index,
+                repr(value & ~G90SensorUserFlags.USER_SETTABLE)
             )
 
         await self._set_protocol_data(
@@ -663,7 +666,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             return False
 
         # Checking private attribute directly, since `mypy` doesn't recognize
-        # the check for sensor definition is done over `self.supports_updates`
+        # the check for entity definition is done over `self.supports_updates`
         # property
         assert self.definition is not None
 
@@ -820,8 +823,8 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
 
         if result is None:
             raise ValueError(
-                f"Unknown alert mode for sensor {self.name}: {mode}"
-                f" (user flag: {self.user_flag})"
+                f"Unknown alert mode for {self._entity_kind} {self.name}:"
+                f" {mode} (user flag: {self.user_flag})"
             )
 
         return result
@@ -844,8 +847,8 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
 
         if result is None:
             raise ValueError(
-                f"Attempting to set alert mode for sensor {self.name} to"
-                f" unknown value '{value}'"
+                f"Attempting to set alert mode for {self._entity_kind}"
+                f" {self.name} to unknown value '{value}'"
             )
 
         # Add the mapped value over the user flags, filtering out previous
@@ -884,7 +887,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         """
         Deletes the sensor from the alarm panel.
         """
-        _LOGGER.debug("Deleting sensor: %s", self)
+        _LOGGER.debug("Deleting %s: %s", self._entity_kind, self)
 
         # Mark the sensor as unavailable
         self.is_unavailable = True

--- a/src/pyg90alarm/entities/sensor.py
+++ b/src/pyg90alarm/entities/sensor.py
@@ -246,6 +246,27 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         return f'{self._protocol_data.parent_name}#{self._subindex + 1}'
 
     @property
+    def _get_list_command(self) -> G90Commands:
+        """
+        Panel command used to refresh this entity.
+        """
+        return G90Commands.GETSENSORLIST
+
+    @property
+    def _set_single_command(self) -> G90Commands:
+        """
+        Panel command used to write this entity.
+        """
+        return G90Commands.SETSINGLESENSOR
+
+    @property
+    def _entity_kind(self) -> str:
+        """
+        Entity kind used for logging.
+        """
+        return 'sensor'
+
+    @property
     def state_callback(self) -> G90CallbackList[SensorStateCallback]:
         """
         Callback that is invoked when the sensor changes its state.
@@ -461,7 +482,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         """
         if not self.definition:
             _LOGGER.debug(
-                'Manipulating with user flags for sensor index=%s'
+                'Manipulating sensor at index=%s'
                 ' is unsupported - no sensor definition for'
                 ' type=%s, subtype=%s, protocol=%s',
                 self.index, self.type, self.subtype, self.protocol
@@ -585,15 +606,6 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
           :attr:`.G90SensorUserFlags.USER_SETTABLE` will be ignored and
           preserved from existing sensor flags.
         """
-        if not self.supports_updates:
-            return
-
-        # Checking private attribute directly, since `mypy` doesn't recognize
-        # the check for sensor definition is done over
-        # `self.supports_updates` property
-        if not self.definition:
-            return
-
         if value & ~G90SensorUserFlags.USER_SETTABLE:
             _LOGGER.debug(
                 'User flags for sensor index=%s contain non-user settable'
@@ -601,73 +613,112 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
                 self.index, repr(value & ~G90SensorUserFlags.USER_SETTABLE)
             )
 
-        # Refresh actual sensor data from the alarm panel before modifying it.
-        # This implies the sensor is at the same position within sensor list
+        await self._set_protocol_data(
+            'set user flags',
+            user_flags_data=(
+                # Preserve flags that are not user-settable
+                self.user_flags & ~G90SensorUserFlags.USER_SETTABLE
+            ) | (
+                # Combine them with the new user-settable flags
+                value & G90SensorUserFlags.USER_SETTABLE
+            )
+        )
+
+    async def set_name(self, value: str) -> None:
+        """
+        Sets sensor name on the panel.
+
+        For multi-node entities the name is shared by all nodes on the panel;
+        node suffixes are derived locally when the :attr:`name` is read.
+
+        :param value: Name to set.
+        """
+        if self._protocol_data.parent_name == value:
+            _LOGGER.debug(
+                '%s index=%s: name %s has not changed, skipping update',
+                self._entity_kind, self.index, repr(value)
+            )
+            return
+
+        # Set the name refreshing the entities from panel once done - that
+        # ensures the list of entities reflects recent changes
+        await self._set_protocol_data(
+            'set name', refresh_after_update=True, parent_name=value
+        )
+
+    async def _set_protocol_data(
+        self, operation: str, refresh_after_update: bool = False,
+        **updates: Any
+    ) -> bool:
+        """
+        Updates protocol data on the panel.
+
+        :param operation: Operation description for logging.
+        :param refresh_after_update: Refresh cached entities from the panel
+          after updating.
+        :param updates: Protocol data fields to update.
+        :return: True if the update has been sent to the panel.
+        """
+        if not self.supports_updates:
+            return False
+
+        # Checking private attribute directly, since `mypy` doesn't recognize
+        # the check for sensor definition is done over `self.supports_updates`
+        # property
+        assert self.definition is not None
+
+        # Refresh actual entity data from the alarm panel before modifying it.
+        # This implies the entity is at the same position within protocol list
         # (`_proto_index`) as it has been read initially from the alarm panel
         # when instantiated.
         _LOGGER.debug(
-            'Refreshing sensor at index=%s, position in protocol list=%s',
-            self.index, self.proto_idx
+            'Refreshing %s at index=%s, position in protocol list=%s',
+            self._entity_kind, self.index, self.proto_idx
         )
-        sensors_result = self.parent.paginated_result(
-            G90Commands.GETSENSORLIST,
+        entities_result = self.parent.paginated_result(
+            self._get_list_command,
             start=self.proto_idx, end=self.proto_idx
         )
-        sensors = [x.data async for x in sensors_result]
+        entities = [x.data async for x in entities_result]
 
-        # Abort if sensor is not found
-        if not sensors:
+        # Abort if entity is not found
+        if not entities:
             _LOGGER.error(
-                'Sensor index=%s not found when attempting to set its'
-                ' user flag',
-                self.index,
+                '%s index=%s not found when attempting to %s',
+                self._entity_kind, self.index, operation
             )
-            return
+            return False
 
-        # Compare actual sensor data from what the sensor has been instantiated
+        # Compare actual entity data from what the entity has been instantiated
         # from, and abort the operation if out-of-band changes are detected.
-        sensor_data = sensors[0]
-        if self._protocol_incoming_data_kls(
-            *sensor_data
-        ) != self._protocol_data:
+        actual_data = self._protocol_incoming_data_kls(*entities[0])
+        if actual_data != self._protocol_data:
             _LOGGER.error(
-                "Sensor index=%s '%s' has been changed externally,"
-                " refusing to alter its user flag",
-                self.index,
-                self.name
+                "%s index=%s '%s' has been changed externally,"
+                " refusing to %s",
+                self._entity_kind, self.index, self.name,
+                operation
             )
-            return
+            return False
 
-        prev_user_flags = self.user_flags
+        # Re-instantiate the protocol data with modified fields
+        _data = asdict(actual_data)
+        _data.update(updates)
+        new_protocol_data = self._protocol_incoming_data_kls(**_data)
 
-        # Re-instantiate the protocol data with modified user flags
-        _data = asdict(self._protocol_data)
-        _data['user_flags_data'] = (
-            # Preserve flags that are not user-settable
-            self.user_flags & ~G90SensorUserFlags.USER_SETTABLE
-        ) | (
-            # Combine them with the new user-settable flags
-            value & G90SensorUserFlags.USER_SETTABLE
-        )
-        self._protocol_data = self._protocol_incoming_data_kls(**_data)
-
-        if self.user_flags == prev_user_flags:
+        if new_protocol_data == self._protocol_data:
             _LOGGER.debug(
-                'Sensor index=%s: user flags %s have not changed,'
+                '%s index=%s: %s has not changed,'
                 ' skipping update',
-                self._protocol_data.index, repr(prev_user_flags)
+                self._entity_kind, self._protocol_data.index,
+                operation
             )
-            return
+            return False
 
-        _LOGGER.debug(
-            'Sensor index=%s: previous user flags %s, resulting flags %s',
-            self._protocol_data.index,
-            repr(prev_user_flags),
-            repr(self.user_flags)
-        )
+        self._protocol_data = new_protocol_data
 
         # Generate protocol data from write operation, deriving values either
-        # from fields read from the sensor, or from the sensor definition - not
+        # from fields read from the entity, or from the entity definition - not
         # all fields are present during read, only in definition.
         outgoing_data = self._protocol_outgoing_data_kls(
             parent_name=self._protocol_data.parent_name,
@@ -685,10 +736,22 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
             tx=self.definition.tx,
             private_data=self.definition.private_data,
         )
-        # Modify the sensor
+        # Modify the entity
         await self._parent.command(
-            G90Commands.SETSINGLESENSOR, list(astuple(outgoing_data))
+            self._set_single_command, list(astuple(outgoing_data))
         )
+
+        # Refresh the entities from the panel if requested
+        if refresh_after_update:
+            await self._refresh_entities()
+
+        return True
+
+    async def _refresh_entities(self) -> None:
+        """
+        Refreshes cached entities from the panel.
+        """
+        await self.parent.get_sensors()
 
     def get_flag(self, flag: G90SensorUserFlags) -> bool:
         """
@@ -886,6 +949,7 @@ class G90Sensor(G90BaseEntity):  # pylint:disable=too-many-instance-attributes
         return (
             self.type == value.type
             and self.subtype == value.subtype
+            and self.protocol == value.protocol
             and self.index == value.index
-            and self.name == value.name
+            and self.subindex == value.subindex
         )

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -96,8 +96,62 @@ async def test_multinode_device(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[138,'
-    b'[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0',
+    b'ISTART[138,[[1,1,1],["Socket",10,0,128,3,0,32,1190,0,17,1,0,""]]]IEND\0',
+    b'ISTART[138,[[1,1,1],["Socket",10,0,128,3,0,32,1190,0,17,1,0,""]]]IEND\0',
+    b"ISTARTIEND\0",
+    b'ISTART[138,[[1,1,1],["Renamed socket",10,0,128,3,0,32,1190,0,17,1,0,""]'
+    b']]IEND\0',
+])
+async def test_device_set_name(mock_device: DeviceMock) -> None:
+    """
+    Tests for setting a device name.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    devices = await g90.get_devices()
+    await devices[0].set_name('Renamed socket')
+    assert devices[0].name == 'Renamed socket'
+    assert await mock_device.recv_data == [
+        b'ISTART[138,138,[138,[1,10]]]IEND\0',
+        b'ISTART[138,138,[138,[1,1]]]IEND\0',
+        b'ISTART[140,140,[140,'
+        b'["Renamed socket",10,0,128,3,0,32,1190,0,17,1,0,2,"060A0600"]'
+        b']]IEND\0',
+        b'ISTART[138,138,[138,[1,10]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[138,[[1,1,1],["Relay",10,0,128,0,0,32,1480,0,17,4,0,""]]]IEND\0',
+    b'ISTART[138,[[1,1,1],["Relay",10,0,128,0,0,32,1480,0,17,4,0,""]]]IEND\0',
+    b"ISTARTIEND\0",
+    b'ISTART[138,[[1,1,1],["Renamed",10,0,128,0,0,32,1480,0,17,4,0,""]'
+    b']]IEND\0',
+])
+async def test_multinode_device_set_name(mock_device: DeviceMock) -> None:
+    """
+    Tests for setting a multi-node device name from a specific node.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    devices = await g90.get_devices()
+    await devices[2].set_name('Renamed')
+    assert [device.name for device in devices] == [
+        'Renamed#1',
+        'Renamed#2',
+        'Renamed#3',
+        'Renamed#4',
+    ]
+    assert await mock_device.recv_data == [
+        b'ISTART[138,138,[138,[1,10]]]IEND\0',
+        b'ISTART[138,138,[138,[1,1]]]IEND\0',
+        b'ISTART[140,140,[140,'
+        b'["Renamed",10,0,128,0,0,32,1480,0,17,4,0,2,"0707070B0B0D0D0E0E00"]'
+        b']]IEND\0',
+        b'ISTART[138,138,[138,[1,10]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[138,[[1,1,1],["Switch",10,0,10,1,0,32,0,0,16,1,0,""]]]IEND\0',
     b'ISTARTIEND\0',
     b'ISTARTIEND\0',
 ])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -393,19 +393,10 @@ async def test_sensor_set_user_flags(
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
     b"ISTARTIEND\0",
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Renamed cord",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Renamed",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
 ])
 async def test_sensor_set_name(mock_device: DeviceMock) -> None:
     """
@@ -413,23 +404,19 @@ async def test_sensor_set_name(mock_device: DeviceMock) -> None:
     """
     g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
     sensors = await g90.sensors
-    await sensors[0].set_name('Renamed cord')
-    assert sensors[0].name == 'Renamed cord'
+    await sensors[0].set_name('Renamed')
+    assert sensors[0].name == 'Renamed'
     assert await mock_device.recv_data == [
         b'ISTART[102,102,[102,[1,10]]]IEND\0',
         b'ISTART[102,102,[102,[1,1]]]IEND\0',
-        b'ISTART[103,103,[103,'
-        b'["Renamed cord",10,0,126,1,0,33,0,5,16,1,0,0,"00"]'
+        b'ISTART[103,103,[103,["Renamed",10,0,126,1,0,33,0,5,16,1,0,0,"00"]'
         b']]IEND\0',
         b'ISTART[102,102,[102,[1,10]]]IEND\0',
     ]
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
 ])
 async def test_sensor_set_name_not_changed(mock_device: DeviceMock) -> None:
     """
@@ -445,14 +432,8 @@ async def test_sensor_set_name_not_changed(mock_device: DeviceMock) -> None:
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,1,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,1,0,5,16,1,0,""]]]IEND\0',
 ])
 async def test_sensor_set_name_externally_modified(
     mock_device: DeviceMock
@@ -471,10 +452,7 @@ async def test_sensor_set_name_externally_modified(
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
     b'ISTART[102,[[1,1,0]]]IEND\0',
 ])
 async def test_sensor_set_name_not_found_on_refresh(
@@ -494,10 +472,7 @@ async def test_sensor_set_name_not_found_on_refresh(
 
 
 @pytest.mark.g90device(sent_data=[
-    b'ISTART[102,'
-    b'[[1,1,1],'
-    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
-    b']]IEND\0',
+    b'ISTART[102,[[1,1,1],["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]]]IEND\0',
     b"ISTARTIEND\0",
 ])
 async def test_sensor_delete(mock_device: DeviceMock) -> None:
@@ -515,14 +490,12 @@ async def test_sensor_delete(mock_device: DeviceMock) -> None:
 
 
 REGISTER_SENSOR_SENT_DATA = [
-    b'ISTART[102,'
-    b'[[2,1,2],'
+    b'ISTART[102,[[2,1,2],'
     b'["Cord 1",11,0,126,1,0,63,0,5,16,1,0,""],'
     b'["Cord 2",10,0,126,1,0,63,0,5,16,1,0,""]'
     b']]IEND\0',
     b'ISTARTIEND\0',
-    b'ISTART[102,'
-    b'[[3,1,3],'
+    b'ISTART[102,[[3,1,3],'
     b'["Cord 1",11,0,126,1,0,63,0,5,16,1,0,""],'
     b'["Cord 2",10,0,126,1,0,63,0,5,16,1,0,""],'
     b'["Test sensor",3,0,1,3,0,33,0,0,0,1,0,""]'

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -397,6 +397,107 @@ async def test_sensor_set_user_flags(
     b'[[1,1,1],'
     b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
     b']]IEND\0',
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
+    b"ISTARTIEND\0",
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Renamed cord",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
+])
+async def test_sensor_set_name(mock_device: DeviceMock) -> None:
+    """
+    Tests for setting a sensor name.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].set_name('Renamed cord')
+    assert sensors[0].name == 'Renamed cord'
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[1,1]]]IEND\0',
+        b'ISTART[103,103,[103,'
+        b'["Renamed cord",10,0,126,1,0,33,0,5,16,1,0,0,"00"]'
+        b']]IEND\0',
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
+])
+async def test_sensor_set_name_not_changed(mock_device: DeviceMock) -> None:
+    """
+    Tests for setting the same sensor name.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].set_name('Cord 2')
+    assert sensors[0].name == 'Cord 2'
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,1,0,5,16,1,0,""]'
+    b']]IEND\0',
+])
+async def test_sensor_set_name_externally_modified(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for renaming a sensor that has been modified externally.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].set_name('Renamed cord')
+    assert sensors[0].name == 'Cord 2'
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[1,1]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
+    b'ISTART[102,[[1,1,0]]]IEND\0',
+])
+async def test_sensor_set_name_not_found_on_refresh(
+    mock_device: DeviceMock
+) -> None:
+    """
+    Tests for renaming a sensor that is not found on refresh.
+    """
+    g90 = G90Alarm(host=mock_device.host, port=mock_device.port)
+    sensors = await g90.sensors
+    await sensors[0].set_name('Renamed cord')
+    assert sensors[0].name == 'Cord 2'
+    assert await mock_device.recv_data == [
+        b'ISTART[102,102,[102,[1,10]]]IEND\0',
+        b'ISTART[102,102,[102,[1,1]]]IEND\0',
+    ]
+
+
+@pytest.mark.g90device(sent_data=[
+    b'ISTART[102,'
+    b'[[1,1,1],'
+    b'["Cord 2",10,0,126,1,0,33,0,5,16,1,0,""]'
+    b']]IEND\0',
     b"ISTARTIEND\0",
 ])
 async def test_sensor_delete(mock_device: DeviceMock) -> None:


### PR DESCRIPTION
* Manipulating sensor/switch settings (including name) is now generalized to `G90Sensor._set_protocol_data()` method, which is mostly based on setting user flags functionality previously available.
* Added `G90Sensor.set_name()` method that allows to change entity name in the panel
* `G90Device` class no longer overrides `supports_updates()` method always returning `False`, which prevented switch name from being changed. Now the method is derived from parent class and allows for updating the entity if there is a corresponding definition
* Equality test for `G90Sensor` class has been updated to use `protocol` and `subindex` properties instead of `name`, since the latter no longer uniquely represents the entity
* Added tests for the changes