### PR TITLE
fix: Use `iscoroutinefunction` from `inspect` instead of `asyncio`

### DIFF
--- a/src/pyg90alarm/callback.py
+++ b/src/pyg90alarm/callback.py
@@ -23,6 +23,7 @@ Implements callbacks.
 """
 from __future__ import annotations
 import asyncio
+import inspect
 from functools import (partial, wraps)
 from asyncio import Task
 from typing import (
@@ -59,7 +60,7 @@ class G90Callback:
                       ' (args: %s, kwargs: %s)',
                       callback, args, kwargs)
 
-        if not asyncio.iscoroutinefunction(callback):
+        if not inspect.iscoroutinefunction(callback):
             def async_wrapper(
                 func: Callable[..., None]
             ) -> Callable[..., Coroutine[Any, Any, None]]:


### PR DESCRIPTION
`asyncio.iscoroutinefunction` is [pending removal in Python 3.16](https://docs.python.org/3/deprecations/pending-removal-in-3.16.html) and has been replaced with `inspect.iscoroutinefunction`