### PR TITLE
feat!: Remove Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.9'
-            toxenv: py
-          - os: ubuntu-latest
             python: '3.10'
             toxenv: py
           - os: ubuntu-latest
@@ -108,7 +105,7 @@ jobs:
       - name: Set Python up
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: 3.14
       - name: Install the PEP517 package builder
         run: python -m pip install --upgrade build
       - name: Build the package

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,8 @@
 sphinx-rtd-theme
 enum-tools[sphinx]
-sphinx-autodoc-typehints==2.3.0; python_version < '3.11'
 # `spinx-autodoc-typehints` 3.6+ require Sphinx 9.x - pin it to 3.5.2 last
 # supporting Sphinx 8.x (see below for the reason)
-sphinx-autodoc-typehints==3.5.2; python_version >= '3.11'
+sphinx-autodoc-typehints==3.5.2
 pygments>=2.20.0 # not directly required, pinned by Snyk to avoid a vulnerability
 # enum_tools.autoenum doesn't support sphinx 9.x yet,
 # https://github.com/domdfcoding/enum_tools/issues/118

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,8 @@
 check-manifest == 0.51
 flake8 == 7.3.0
-pytest==8.4.2; python_version < '3.10'
-pytest==9.0.3; python_version >= '3.10'
-pytest-asyncio==1.2.0; python_version < '3.10'
-pytest-asyncio==1.3.0; python_version >= '3.10'
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov == 7.1.0
-pylint==3.3.9; python_version < '3.10'
-pylint==4.0.4; python_version >= '3.10'
+pylint==4.0.4
 mypy[reports] == 1.19.1
 freezegun == 1.5.5

--- a/setup.py
+++ b/setup.py
@@ -38,18 +38,18 @@ setup(
         'Topic :: System :: Hardware',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: 3 :: Only',
     ],
 
     keywords='g90, alarm, protocol',
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
-    python_requires='>=3.9, <4',
+    python_requires='>=3.10, <4',
     install_requires=[],
 
     extras_require={

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.python.version=3.9, 3.10, 3.11, 3.12, 3.13
+sonar.python.version=3.10, 3.11, 3.12, 3.13, 3.14
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.pylint.reportPaths=pylint.txt
 sonar.python.flake8.reportPaths=flake8.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313,314}
+envlist = py{310,311,312,313,314}
 
 # Define the minimal tox version required to run;
 # if the host tox is less than this the tool with create an environment and


### PR DESCRIPTION
Python 3.9 reached end of life at Oct 2025 and most of the dependencies are not updated for it, hence the package no longer supports it officially